### PR TITLE
Surface contact details across the site

### DIFF
--- a/components/ContactLinks.tsx
+++ b/components/ContactLinks.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import { Phone, MessageCircle, Mail, Instagram } from "lucide-react";
+import {
+  PHONE_NUMBER_DISPLAY,
+  PHONE_TEL,
+  WHATSAPP_URL,
+  EMAIL,
+  EMAIL_MAILTO,
+  INSTAGRAM_URL,
+} from "../lib/constants";
+
+type Theme = "dark" | "light";
+type Layout = "row" | "stack";
+
+interface ContactLinksProps {
+  theme?: Theme;
+  layout?: Layout;
+  showLabels?: boolean;
+  includeInstagram?: boolean;
+  className?: string;
+}
+
+interface ContactItem {
+  href: string;
+  external: boolean;
+  icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
+  label: string;
+  value: string;
+  ariaLabel: string;
+}
+
+const buildItems = (includeInstagram: boolean): ContactItem[] => {
+  const items: ContactItem[] = [
+    {
+      href: PHONE_TEL,
+      external: false,
+      icon: Phone,
+      label: "Call",
+      value: PHONE_NUMBER_DISPLAY,
+      ariaLabel: `Call ${PHONE_NUMBER_DISPLAY}`,
+    },
+    {
+      href: WHATSAPP_URL,
+      external: true,
+      icon: MessageCircle,
+      label: "WhatsApp",
+      value: PHONE_NUMBER_DISPLAY,
+      ariaLabel: `Chat on WhatsApp at ${PHONE_NUMBER_DISPLAY}`,
+    },
+    {
+      href: EMAIL_MAILTO,
+      external: false,
+      icon: Mail,
+      label: "Email",
+      value: EMAIL,
+      ariaLabel: `Email ${EMAIL}`,
+    },
+  ];
+
+  if (includeInstagram) {
+    items.push({
+      href: INSTAGRAM_URL,
+      external: true,
+      icon: Instagram,
+      label: "Instagram",
+      value: "@tarang.hirani",
+      ariaLabel: "Follow on Instagram",
+    });
+  }
+
+  return items;
+};
+
+const ContactLinks: React.FC<ContactLinksProps> = ({
+  theme = "dark",
+  layout = "row",
+  showLabels = false,
+  includeInstagram = false,
+  className = "",
+}) => {
+  const items = buildItems(includeInstagram);
+
+  const isDark = theme === "dark";
+  const isStack = layout === "stack";
+
+  const baseText = isDark ? "text-white/60" : "text-smoke";
+  const hoverText = isDark ? "hover:text-sage" : "hover:text-sage";
+  const labelColor = isDark ? "text-sage/80" : "text-sage";
+  const valueColor = isDark ? "text-white/90" : "text-charcoal";
+  const dividerBg = isDark ? "bg-white/10" : "bg-charcoal/10";
+
+  if (isStack) {
+    return (
+      <ul className={`flex flex-col ${className}`}>
+        {items.map((item, idx) => {
+          const Icon = item.icon;
+          return (
+            <li key={item.label}>
+              <a
+                href={item.href}
+                target={item.external ? "_blank" : undefined}
+                rel={item.external ? "noopener noreferrer" : undefined}
+                aria-label={item.ariaLabel}
+                className={`group flex items-center gap-5 py-5 transition-colors duration-300 ${baseText} ${hoverText}`}
+              >
+                <span
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border ${
+                    isDark ? "border-white/15" : "border-charcoal/15"
+                  } transition-colors duration-300 group-hover:border-sage`}
+                >
+                  <Icon size={18} strokeWidth={1.5} />
+                </span>
+                <span className="flex flex-1 flex-col items-start">
+                  <span
+                    className={`font-display text-[11px] uppercase tracking-[0.2em] ${labelColor}`}
+                  >
+                    {item.label}
+                  </span>
+                  <span
+                    className={`mt-1 text-base md:text-lg ${valueColor} transition-colors duration-300 group-hover:text-sage`}
+                  >
+                    {item.value}
+                  </span>
+                </span>
+                <span
+                  aria-hidden
+                  className="text-sage opacity-0 transition-all duration-300 group-hover:opacity-100 group-hover:translate-x-1"
+                >
+                  &rarr;
+                </span>
+              </a>
+              {idx < items.length - 1 && (
+                <div className={`h-px w-full ${dividerBg}`} />
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  return (
+    <ul
+      className={`flex flex-wrap items-center justify-center gap-x-6 gap-y-3 md:gap-x-8 ${className}`}
+    >
+      {items.map((item) => {
+        const Icon = item.icon;
+        return (
+          <li key={item.label}>
+            <a
+              href={item.href}
+              target={item.external ? "_blank" : undefined}
+              rel={item.external ? "noopener noreferrer" : undefined}
+              aria-label={item.ariaLabel}
+              className={`group inline-flex items-center gap-2 text-xs md:text-sm transition-colors duration-300 ${baseText} ${hoverText}`}
+            >
+              <Icon size={14} strokeWidth={1.5} />
+              {showLabels && (
+                <span className="font-display uppercase tracking-[0.15em]">
+                  {item.label}
+                </span>
+              )}
+              <span className="tracking-wide">{item.value}</span>
+            </a>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default ContactLinks;

--- a/components/FloatingWhatsApp.tsx
+++ b/components/FloatingWhatsApp.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useRouter } from "next/router";
+import { MessageCircle } from "lucide-react";
+import { WHATSAPP_URL, PHONE_NUMBER_DISPLAY } from "../lib/constants";
+
+const FloatingWhatsApp: React.FC = () => {
+  const { pathname } = useRouter();
+
+  if (pathname === "/contact") return null;
+
+  return (
+    <a
+      href={WHATSAPP_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`Chat on WhatsApp at ${PHONE_NUMBER_DISPLAY}`}
+      className="md:hidden fixed bottom-6 right-6 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-charcoal border border-sage text-sage shadow-[0_8px_24px_rgba(0,0,0,0.35)] transition-colors duration-300 hover:bg-sage hover:text-charcoal"
+    >
+      <MessageCircle size={22} strokeWidth={1.5} />
+    </a>
+  );
+};
+
+export default FloatingWhatsApp;

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Instagram } from "lucide-react";
 import { INSTAGRAM_URL } from "../lib/constants";
 import EmailSignup from "./EmailSignup";
+import ContactLinks from "./ContactLinks";
 
 // Defined once when the module loads
 const currentYear = new Date().getFullYear();
@@ -14,6 +15,15 @@ const Footer: React.FC = () => {
         {/* Email signup */}
         <div className="flex justify-center">
           <EmailSignup variant="inline" theme="dark" />
+        </div>
+
+        {/* Contact details */}
+        <div className="flex flex-col items-center gap-4 pt-2">
+          <div className="h-px w-12 bg-sage" />
+          <p className="font-display text-[11px] uppercase tracking-[0.2em] text-sage/80">
+            Get in Touch
+          </p>
+          <ContactLinks theme="dark" layout="row" />
         </div>
 
         {/* Bottom row: copyright + Instagram */}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { Playfair_Display, Source_Sans_3 } from "next/font/google";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
+import FloatingWhatsApp from "./FloatingWhatsApp";
 
 const playfair = Playfair_Display({
   subsets: ["latin"],
@@ -27,7 +28,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const isHome = pathname === "/";
   const isGallery = pathname === "/gallery";
   const isBlog = pathname.startsWith("/blog");
-  const needsTopPadding = !isHome && !isGallery && !isBlog;
+  const isContact = pathname === "/contact";
+  const needsTopPadding = !isHome && !isGallery && !isBlog && !isContact;
 
   return (
     <div
@@ -38,6 +40,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         {children}
       </main>
       <Footer />
+      <FloatingWhatsApp />
     </div>
   );
 };

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { href: "/", label: "Home" },
   { href: "/gallery", label: "Gallery" },
   { href: "/blog", label: "Field Notes" },
+  { href: "/contact", label: "Contact" },
 ];
 
 const getLinkClasses = (

--- a/components/SafariOffering.tsx
+++ b/components/SafariOffering.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import FadeIn from "./FadeIn";
+import ContactLinks from "./ContactLinks";
 
 export default function SafariOffering() {
   return (
@@ -26,6 +27,14 @@ export default function SafariOffering() {
               &rarr;
             </span>
           </a>
+
+          <div className="mt-12 flex flex-col items-center gap-4">
+            <div className="h-px w-8 bg-white/15" />
+            <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-gray-500">
+              Or reach us directly
+            </p>
+            <ContactLinks theme="dark" layout="row" />
+          </div>
         </FadeIn>
       </div>
     </section>

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -1,1 +1,7 @@
 export const INSTAGRAM_URL = "https://www.instagram.com/tarang.hirani/?hl=en";
+
+export const PHONE_NUMBER_DISPLAY = "+91 70300 47045";
+export const PHONE_TEL = "tel:+917030047045";
+export const WHATSAPP_URL = "https://wa.me/917030047045";
+export const EMAIL = "safaris@taranghirani.com";
+export const EMAIL_MAILTO = "mailto:safaris@taranghirani.com";

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,48 @@
+import Head from "next/head";
+import FadeIn from "../components/FadeIn";
+import ContactLinks from "../components/ContactLinks";
+
+export default function ContactPage() {
+  return (
+    <>
+      <Head>
+        <title>Contact | Tarang Hirani</title>
+        <meta
+          name="description"
+          content="Get in touch with Tarang Hirani to enquire about wildlife safaris in India and Africa, prints, collaborations, or commissions. Call, WhatsApp, or email."
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+
+      <section className="bg-charcoal min-h-screen pt-32 pb-24 md:pt-40 md:pb-32">
+        <div className="mx-auto max-w-2xl px-6 md:px-12">
+          <FadeIn>
+            <div className="text-center">
+              <div className="mx-auto h-px w-12 bg-sage" />
+              <p className="mt-8 text-[11px] font-medium uppercase tracking-[0.2em] text-sage">
+                Get in Touch
+              </p>
+              <h1 className="mt-4 font-display text-4xl md:text-5xl lg:text-6xl font-semibold text-parchment tracking-tight">
+                Let&apos;s talk.
+              </h1>
+              <p className="mt-6 text-base md:text-lg leading-relaxed text-white/60">
+                Whether you&apos;re planning a safari in India or Africa, looking
+                for prints, or want to collaborate, the fastest way to reach me
+                is on WhatsApp or email. I read every message.
+              </p>
+            </div>
+
+            <div className="mt-14 md:mt-16">
+              <ContactLinks
+                theme="dark"
+                layout="stack"
+                showLabels
+                includeInstagram
+              />
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -3,6 +3,7 @@
 <url><loc>https://www.taranghirani.com</loc><lastmod>2026-04-12T16:31:21.878Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://www.taranghirani.com/blog</loc><lastmod>2026-04-12T16:31:21.879Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://www.taranghirani.com/gallery</loc><lastmod>2026-04-12T16:31:21.879Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com/contact</loc><lastmod>2026-06-02T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
 <url><loc>https://www.taranghirani.com/blog/understanding-behavior</loc><lastmod>2026-04-12T16:31:21.879Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://www.taranghirani.com/blog/shooting-with-intent</loc><lastmod>2026-04-12T16:31:21.879Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
## Summary
- Adds phone (`+91 70300 47045`), WhatsApp, and email (`safaris@taranghirani.com`) as first-class entry points alongside the existing Instagram CTA — so customers who prefer calling, WhatsApp, or email aren't forced through DMs.
- New reusable `ContactLinks` component (row / stack layouts, dark / light themes) keeps presentation consistent and the data centralised in `lib/constants/index.ts`.
- Surfaces contact info in five places: footer (every page), `SafariOffering` secondary row, navbar (`Contact` link), mobile floating WhatsApp pill, and a dedicated `/contact` page (added to sitemap).

## Files
- `lib/constants/index.ts` — new phone / WhatsApp / email constants
- `components/ContactLinks.tsx` *(new)* — shared presentational component
- `components/Footer.tsx` — "Get in Touch" block above the bottom row
- `components/SafariOffering.tsx` — Instagram CTA stays primary; phone / WhatsApp / email added as a quieter secondary row
- `components/Navbar.tsx` — `Contact` added to `navItems` (picks up desktop + mobile menu)
- `components/FloatingWhatsApp.tsx` *(new)* — `md:hidden`, `z-40`, hidden on `/contact`, charcoal + sage (no WhatsApp green) to respect brand restraint
- `components/Layout.tsx` — mounts `FloatingWhatsApp`; excludes `/contact` from default top padding so the hero handles its own spacing
- `pages/contact.tsx` *(new)* — charcoal hero with sage hairline, "Let's talk." headline, stacked Call / WhatsApp / Email / Instagram with icons + uppercase labels
- `public/sitemap-0.xml` — `/contact` entry (priority 0.8); `next-sitemap` will also regenerate it on next build

## Design notes
- Sage accent kept ≤5% of composition (hairlines, labels, hover states only) per `DESIGN.md`
- Tracking, casing, and weights match existing CTAs (`tracking-[0.15em] uppercase`, font-display)
- Floating button uses brand charcoal + sage rather than WhatsApp green to stay consistent with the editorial tone

## Test plan
- [ ] `yarn dev` and walk Home → Gallery → Blog → Blog post → Contact; footer "Get in Touch" block appears on each
- [ ] Navbar shows `Contact`; active state highlights on `/contact` (desktop + mobile)
- [ ] Home `SafariOffering` shows Instagram CTA primary, phone/WhatsApp/email secondary
- [ ] Mobile viewport: floating WhatsApp button visible on Home/Gallery/Blog; hidden on `/contact`
- [ ] Tap each link: dialer opens for phone, `wa.me/917030047045` for WhatsApp, mail client for email
- [ ] Lightbox on `/gallery` still covers the floating button (z-50 vs z-40)
- [ ] `tsc --noEmit` is clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)