### PR TITLE
Add contact form with Resend integration

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -2,6 +2,10 @@ import React, { FormEvent, useState } from "react";
 
 type Status = "idle" | "loading" | "success" | "error";
 
+type Source = "contact" | "workshops";
+
+type Theme = "dark" | "light";
+
 type FieldErrors = Partial<
   Record<"name" | "email" | "phone" | "message", string>
 >;
@@ -36,19 +40,6 @@ const COUNTRY_CODES: { code: string; label: string }[] = [
   { code: "+972", label: "Israel" },
   { code: "+90", label: "Turkey" },
 ];
-
-const labelClass =
-  "block text-[11px] font-medium uppercase tracking-[0.2em] text-sage/80 mb-3";
-const baseInputClass =
-  "w-full bg-transparent border-0 border-b px-0 py-3 text-base text-white placeholder:text-white/25 focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50";
-
-function inputClass(hasError: boolean) {
-  return `${baseInputClass} ${
-    hasError
-      ? "border-red-400/70 focus:border-red-400"
-      : "border-white/15 focus:border-sage"
-  }`;
-}
 
 function validate(fields: {
   name: string;
@@ -85,7 +76,40 @@ function validate(fields: {
   return errors;
 }
 
-export default function ContactForm() {
+export default function ContactForm({
+  source = "contact",
+  theme = "dark",
+}: {
+  source?: Source;
+  theme?: Theme;
+}) {
+  const isLight = theme === "light";
+
+  // Theme-aware class fragments. Sage stays the accent (hairline, arrow, focus
+  // underline, button border/hover); functional text shifts to charcoal/smoke
+  // on light so it stays legible — sage-on-paper fails contrast.
+  const labelClass = `block text-[11px] font-medium uppercase tracking-[0.2em] mb-3 ${
+    isLight ? "text-smoke" : "text-sage/80"
+  }`;
+  const baseInputClass = `w-full bg-transparent border-0 border-b px-0 py-3 text-base focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 ${
+    isLight
+      ? "text-charcoal placeholder:text-smoke/50"
+      : "text-white placeholder:text-white/25"
+  }`;
+  const normalBorder = isLight ? "border-charcoal/20" : "border-white/15";
+  const errorBorder = isLight
+    ? "border-red-500/70 focus:border-red-500"
+    : "border-red-400/70 focus:border-red-400";
+  const inputClass = (hasError: boolean) =>
+    `${baseInputClass} ${
+      hasError ? errorBorder : `${normalBorder} focus:border-sage`
+    }`;
+  const selectClass = `appearance-none bg-transparent border-0 border-b ${normalBorder} px-0 pr-6 py-3 text-base focus:border-sage focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 cursor-pointer ${
+    isLight ? "text-charcoal" : "text-white"
+  }`;
+  const optionClass = isLight ? "bg-paper text-charcoal" : "bg-charcoal text-white";
+  const errorTextClass = `mt-2 text-xs ${isLight ? "text-red-600" : "text-red-400"}`;
+
   const [status, setStatus] = useState<Status>("idle");
   const [submitError, setSubmitError] = useState<string>("");
   const [countryCode, setCountryCode] = useState("+91");
@@ -120,6 +144,8 @@ export default function ContactForm() {
       message: ((data.get("message") as string) || "").trim(),
     };
 
+    const type = ((data.get("type") as string) || "").trim();
+
     const fieldErrors = validate(fields);
     if (Object.keys(fieldErrors).length > 0) {
       setErrors(fieldErrors);
@@ -135,7 +161,7 @@ export default function ContactForm() {
       const res = await fetch("/api/contact", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...fields, countryCode }),
+        body: JSON.stringify({ ...fields, countryCode, type, source }),
       });
 
       if (res.ok) {
@@ -160,17 +186,23 @@ export default function ContactForm() {
         <p className="mt-8 text-[11px] font-medium uppercase tracking-[0.2em] text-sage">
           Message Received
         </p>
-        <h3 className="mt-4 font-display text-2xl md:text-3xl font-semibold text-parchment tracking-tight">
+        <h3
+          className={`mt-4 font-display text-2xl md:text-3xl font-semibold tracking-tight ${
+            isLight ? "text-charcoal" : "text-parchment"
+          }`}
+        >
           Thanks — I&apos;ll be in touch.
         </h3>
-        <p className="mt-4 text-sm md:text-base text-white/50">
+        <p
+          className={`mt-4 text-sm md:text-base ${
+            isLight ? "text-smoke" : "text-white/50"
+          }`}
+        >
           I read every message and reply within 48 hours.
         </p>
       </div>
     );
   }
-
-  const errorTextClass = "mt-2 text-xs text-red-400";
 
   return (
     <form onSubmit={handleSubmit} className="w-full" noValidate>
@@ -244,14 +276,10 @@ export default function ContactForm() {
               value={countryCode}
               onChange={(e) => setCountryCode(e.target.value)}
               disabled={status === "loading"}
-              className="appearance-none bg-transparent border-0 border-b border-white/15 px-0 pr-6 py-3 text-base text-white focus:border-sage focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 cursor-pointer"
+              className={selectClass}
             >
               {COUNTRY_CODES.map((c) => (
-                <option
-                  key={c.code}
-                  value={c.code}
-                  className="bg-charcoal text-white"
-                >
+                <option key={c.code} value={c.code} className={optionClass}>
                   {c.label} {c.code}
                 </option>
               ))}
@@ -285,6 +313,40 @@ export default function ContactForm() {
       </div>
 
       <div className="mt-8">
+        <label htmlFor="contact-type" className={labelClass}>
+          What&apos;s this about?
+        </label>
+        <div className="relative">
+          <select
+            id="contact-type"
+            name="type"
+            defaultValue=""
+            disabled={status === "loading"}
+            className={`${selectClass} w-full`}
+          >
+            <option value="" className={optionClass}>
+              Select one (optional)
+            </option>
+            <option value="Workshop" className={optionClass}>
+              Workshop
+            </option>
+            <option value="Safari" className={optionClass}>
+              Safari
+            </option>
+            <option value="Other" className={optionClass}>
+              Other
+            </option>
+          </select>
+          <span
+            aria-hidden
+            className="pointer-events-none absolute right-0 bottom-3.5 text-sage text-xs"
+          >
+            ▾
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-8">
         <label htmlFor="contact-message" className={labelClass}>
           Your Message
         </label>
@@ -314,7 +376,11 @@ export default function ContactForm() {
 
       <div className="mt-10 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
         {status === "error" && (
-          <p className="text-sm text-red-400 sm:mr-auto">
+          <p
+            className={`text-sm sm:mr-auto ${
+              isLight ? "text-red-600" : "text-red-400"
+            }`}
+          >
             {submitError}{" "}
             <a
               href="https://wa.me/917030047045"
@@ -329,7 +395,9 @@ export default function ContactForm() {
         <button
           type="submit"
           disabled={status === "loading"}
-          className="group inline-flex items-center justify-center gap-2 px-7 py-3 border border-sage text-sage text-xs uppercase tracking-[0.15em] font-medium hover:bg-sage hover:text-charcoal transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+          className={`group inline-flex items-center justify-center gap-2 px-7 py-3 border border-sage text-xs uppercase tracking-[0.15em] font-medium hover:bg-sage hover:text-charcoal transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed ${
+            isLight ? "text-charcoal" : "text-sage"
+          }`}
         >
           {status === "loading" ? (
             <span className="inline-block h-3 w-3 border border-sage border-t-transparent rounded-full animate-spin" />

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,348 @@
+import React, { FormEvent, useState } from "react";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+type FieldErrors = Partial<
+  Record<"name" | "email" | "phone" | "message", string>
+>;
+
+const COUNTRY_CODES: { code: string; label: string }[] = [
+  { code: "+91", label: "India" },
+  { code: "+1", label: "USA / Canada" },
+  { code: "+44", label: "United Kingdom" },
+  { code: "+61", label: "Australia" },
+  { code: "+971", label: "UAE" },
+  { code: "+65", label: "Singapore" },
+  { code: "+27", label: "South Africa" },
+  { code: "+255", label: "Tanzania" },
+  { code: "+254", label: "Kenya" },
+  { code: "+49", label: "Germany" },
+  { code: "+33", label: "France" },
+  { code: "+31", label: "Netherlands" },
+  { code: "+34", label: "Spain" },
+  { code: "+39", label: "Italy" },
+  { code: "+41", label: "Switzerland" },
+  { code: "+46", label: "Sweden" },
+  { code: "+47", label: "Norway" },
+  { code: "+45", label: "Denmark" },
+  { code: "+81", label: "Japan" },
+  { code: "+82", label: "South Korea" },
+  { code: "+852", label: "Hong Kong" },
+  { code: "+86", label: "China" },
+  { code: "+60", label: "Malaysia" },
+  { code: "+66", label: "Thailand" },
+  { code: "+64", label: "New Zealand" },
+  { code: "+55", label: "Brazil" },
+  { code: "+972", label: "Israel" },
+  { code: "+90", label: "Turkey" },
+];
+
+const labelClass =
+  "block text-[11px] font-medium uppercase tracking-[0.2em] text-sage/80 mb-3";
+const baseInputClass =
+  "w-full bg-transparent border-0 border-b px-0 py-3 text-base text-white placeholder:text-white/25 focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50";
+
+function inputClass(hasError: boolean) {
+  return `${baseInputClass} ${
+    hasError
+      ? "border-red-400/70 focus:border-red-400"
+      : "border-white/15 focus:border-sage"
+  }`;
+}
+
+function validate(fields: {
+  name: string;
+  email: string;
+  phone: string;
+  message: string;
+}): FieldErrors {
+  const errors: FieldErrors = {};
+
+  if (!fields.name) {
+    errors.name = "Please enter your name.";
+  } else if (fields.name.length < 2) {
+    errors.name = "Please enter your full name.";
+  }
+
+  if (!fields.email) {
+    errors.email = "Please enter your email.";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fields.email)) {
+    errors.email = "Please enter a valid email address.";
+  }
+
+  if (!fields.phone) {
+    errors.phone = "Please enter your phone number.";
+  } else if (!/^[\d\s()-]{4,}$/.test(fields.phone)) {
+    errors.phone = "Please enter a valid phone number.";
+  }
+
+  if (!fields.message) {
+    errors.message = "Please add a short message.";
+  } else if (fields.message.length < 10) {
+    errors.message = "Tell me a little more — at least a sentence.";
+  }
+
+  return errors;
+}
+
+export default function ContactForm() {
+  const [status, setStatus] = useState<Status>("idle");
+  const [submitError, setSubmitError] = useState<string>("");
+  const [countryCode, setCountryCode] = useState("+91");
+  const [errors, setErrors] = useState<FieldErrors>({});
+
+  function clearError(field: keyof FieldErrors) {
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (status === "loading") return;
+
+    const form = e.currentTarget;
+    const data = new FormData(form);
+
+    // Honeypot — if filled, silently succeed (bots usually fill all fields)
+    if ((data.get("company") as string)?.trim()) {
+      setStatus("success");
+      return;
+    }
+
+    const fields = {
+      name: ((data.get("name") as string) || "").trim(),
+      email: ((data.get("email") as string) || "").trim(),
+      phone: ((data.get("phone") as string) || "").trim(),
+      message: ((data.get("message") as string) || "").trim(),
+    };
+
+    const fieldErrors = validate(fields);
+    if (Object.keys(fieldErrors).length > 0) {
+      setErrors(fieldErrors);
+      setStatus("idle");
+      return;
+    }
+
+    setErrors({});
+    setStatus("loading");
+    setSubmitError("");
+
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...fields, countryCode }),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+        form.reset();
+        setCountryCode("+91");
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setSubmitError(data.error || "Something went wrong. Try again.");
+        setStatus("error");
+      }
+    } catch {
+      setSubmitError("Something went wrong. Try again.");
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className="text-center py-12">
+        <div className="mx-auto h-px w-12 bg-sage" />
+        <p className="mt-8 text-[11px] font-medium uppercase tracking-[0.2em] text-sage">
+          Message Received
+        </p>
+        <h3 className="mt-4 font-display text-2xl md:text-3xl font-semibold text-parchment tracking-tight">
+          Thanks — I&apos;ll be in touch.
+        </h3>
+        <p className="mt-4 text-sm md:text-base text-white/50">
+          I read every message and reply within 48 hours.
+        </p>
+      </div>
+    );
+  }
+
+  const errorTextClass = "mt-2 text-xs text-red-400";
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full" noValidate>
+      {/* Honeypot — visually hidden but available to bots */}
+      <div className="absolute -left-[9999px]" aria-hidden="true">
+        <label>
+          Company
+          <input
+            type="text"
+            name="company"
+            tabIndex={-1}
+            autoComplete="off"
+          />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-8">
+        <div>
+          <label htmlFor="contact-name" className={labelClass}>
+            Name
+          </label>
+          <input
+            id="contact-name"
+            type="text"
+            name="name"
+            autoComplete="name"
+            disabled={status === "loading"}
+            aria-invalid={!!errors.name}
+            aria-describedby={errors.name ? "contact-name-error" : undefined}
+            onChange={() => clearError("name")}
+            className={inputClass(!!errors.name)}
+          />
+          {errors.name && (
+            <p id="contact-name-error" role="alert" className={errorTextClass}>
+              {errors.name}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="contact-email" className={labelClass}>
+            Email
+          </label>
+          <input
+            id="contact-email"
+            type="email"
+            name="email"
+            autoComplete="email"
+            disabled={status === "loading"}
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? "contact-email-error" : undefined}
+            onChange={() => clearError("email")}
+            className={inputClass(!!errors.email)}
+          />
+          {errors.email && (
+            <p id="contact-email-error" role="alert" className={errorTextClass}>
+              {errors.email}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <label htmlFor="contact-phone" className={labelClass}>
+          Phone
+        </label>
+        <div className="flex items-end gap-3">
+          <div className="relative">
+            <select
+              aria-label="Country code"
+              value={countryCode}
+              onChange={(e) => setCountryCode(e.target.value)}
+              disabled={status === "loading"}
+              className="appearance-none bg-transparent border-0 border-b border-white/15 px-0 pr-6 py-3 text-base text-white focus:border-sage focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 cursor-pointer"
+            >
+              {COUNTRY_CODES.map((c) => (
+                <option
+                  key={c.code}
+                  value={c.code}
+                  className="bg-charcoal text-white"
+                >
+                  {c.label} {c.code}
+                </option>
+              ))}
+            </select>
+            <span
+              aria-hidden
+              className="pointer-events-none absolute right-0 bottom-3.5 text-sage text-xs"
+            >
+              ▾
+            </span>
+          </div>
+          <input
+            id="contact-phone"
+            type="tel"
+            name="phone"
+            inputMode="tel"
+            autoComplete="tel-national"
+            placeholder="98765 43210"
+            disabled={status === "loading"}
+            aria-invalid={!!errors.phone}
+            aria-describedby={errors.phone ? "contact-phone-error" : undefined}
+            onChange={() => clearError("phone")}
+            className={`${inputClass(!!errors.phone)} flex-1`}
+          />
+        </div>
+        {errors.phone && (
+          <p id="contact-phone-error" role="alert" className={errorTextClass}>
+            {errors.phone}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-8">
+        <label htmlFor="contact-message" className={labelClass}>
+          Your Message
+        </label>
+        <textarea
+          id="contact-message"
+          name="message"
+          rows={5}
+          disabled={status === "loading"}
+          placeholder="Tell me what you'd like to learn, where you'd like to go, or what you're hoping to make."
+          aria-invalid={!!errors.message}
+          aria-describedby={
+            errors.message ? "contact-message-error" : undefined
+          }
+          onChange={() => clearError("message")}
+          className={`${inputClass(!!errors.message)} resize-none leading-relaxed`}
+        />
+        {errors.message && (
+          <p
+            id="contact-message-error"
+            role="alert"
+            className={errorTextClass}
+          >
+            {errors.message}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-10 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
+        {status === "error" && (
+          <p className="text-sm text-red-400 sm:mr-auto">
+            {submitError}{" "}
+            <a
+              href="https://wa.me/917030047045"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-sage transition-colors"
+            >
+              Or message me on WhatsApp.
+            </a>
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={status === "loading"}
+          className="group inline-flex items-center justify-center gap-2 px-7 py-3 border border-sage text-sage text-xs uppercase tracking-[0.15em] font-medium hover:bg-sage hover:text-charcoal transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {status === "loading" ? (
+            <span className="inline-block h-3 w-3 border border-sage border-t-transparent rounded-full animate-spin" />
+          ) : (
+            <>
+              Send Enquiry
+              <span className="inline-block transition-transform duration-300 group-hover:translate-x-1">
+                &rarr;
+              </span>
+            </>
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/docs/contact-form-rollout.md
+++ b/docs/contact-form-rollout.md
@@ -1,0 +1,126 @@
+# Contact Form Rollout
+
+## Context
+
+`/contact` now has a typed enquiry form on top of the existing WhatsApp / email / Instagram quick-paths. Submissions are emailed to `safaris@taranghirani.com` and `tarang9211@gmail.com` via Resend, with the enquirer's email set as `Reply-To` so replying from either inbox goes straight back to them.
+
+**Funnel position:**
+
+```
+Website /contact
+    ↓
+Form submission → Resend → inbox (safaris@ + tarang9211@)
+    ↓
+Personal reply / WhatsApp follow-up
+    ↓
+Booking / commission / print sale
+```
+
+This is the lead-capture counterpart to the Kit-driven newsletter funnel — different purpose, different infra. The two should not be merged.
+
+---
+
+## What's already built
+
+- `components/ContactForm.tsx` — name, email, country code + phone, message. Per-field validation, honeypot anti-spam, loading/success/error states.
+- `pages/api/contact.ts` — POST handler that validates input and sends via Resend. Includes plain-text + HTML email bodies.
+- `pages/contact.tsx` — form placed above ContactLinks; new copy ("Looking to learn photography or plan a photography focussed experience?").
+- `resend@6.x` added to dependencies.
+
+---
+
+## 1. Resend Account Setup
+
+**Steps:**
+
+1. Sign up at <https://resend.com> (free tier: 100 emails/day, 3,000/month — more than enough headroom).
+2. Navigate to **API Keys** → **Create API Key**. Name it `taranghirani-website-prod`. Permissions: **Sending access** only.
+3. Copy the key (starts with `re_`). You will not see it again — store in a password manager and immediately add to Vercel + `.env.local` per step 2.
+
+---
+
+## 2. Environment Variables
+
+| Variable               | Where                           | Required | Purpose                                                                                                            |
+| ---------------------- | ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `RESEND_API_KEY`       | Vercel dashboard + `.env.local` | Yes      | Authenticates the Resend send call.                                                                                |
+| `CONTACT_FROM_ADDRESS` | Vercel dashboard + `.env.local` | Optional | Override the From line once a domain is verified (see §4). Falls back to `Tarang Hirani Website <onboarding@resend.dev>`. |
+
+**Vercel setup:**
+
+1. Vercel dashboard → Project → Settings → Environment Variables.
+2. Add `RESEND_API_KEY`, mark **Sensitive**, scope to **Production + Preview**.
+3. Skip `CONTACT_FROM_ADDRESS` for now — only set it after §4 is complete.
+4. Redeploy (or trigger a new build) so the new env reaches the running app.
+
+**Local:**
+
+Append to `.env.local` (already gitignored):
+
+```
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxx
+```
+
+---
+
+## 3. Smoke Test
+
+After the Vercel env var lands and the deploy is live:
+
+1. Open the deployed `/contact` page (production or a Preview URL).
+2. Submit a real enquiry with your own name + a throwaway message ("Test — please ignore").
+3. Confirm:
+   - The form shows the success state ("Thanks — I'll be in touch.").
+   - Both inboxes (`safaris@taranghirani.com` and `tarang9211@gmail.com`) receive the email within ~30 seconds.
+   - The email "From" reads `Tarang Hirani Website <onboarding@resend.dev>` until §4 is done.
+   - Hitting **Reply** in either inbox addresses the enquirer's email, not Resend.
+4. Submit an empty form to verify per-field validation messages appear in red below each field.
+5. Submit a form filled with invalid data (e.g. `not-an-email`) to verify the email format check fires.
+
+---
+
+## 4. Domain Verification (Polished Sender)
+
+**Goal:** change the From line from `onboarding@resend.dev` to something like `enquiries@taranghirani.com` for trust and deliverability.
+
+**Steps:**
+
+1. Resend dashboard → **Domains** → **Add Domain** → enter `taranghirani.com`.
+2. Resend will show 3 DNS records to add:
+   - `MX` for the return-path (e.g. `send.taranghirani.com` → `feedback-smtp.us-east-1.amazonses.com`)
+   - `TXT` for SPF (e.g. `send.taranghirani.com` → `v=spf1 include:amazonses.com ~all`)
+   - `TXT` for DKIM (a long key)
+3. Add all three records in your DNS provider (likely Vercel DNS, Cloudflare, or wherever `taranghirani.com` is hosted). Use the **exact** host names Resend shows — usually scoped to a `send.` subdomain.
+4. Click **Verify** in Resend. Propagation is usually 5–60 minutes; can take up to 24 hours.
+5. Once verified, set the Vercel env var:
+   ```
+   CONTACT_FROM_ADDRESS=Tarang Hirani <enquiries@taranghirani.com>
+   ```
+6. Redeploy. Submit a test enquiry — the From line should now show the branded sender.
+
+**Notes:**
+
+- The verified address does not need to exist as a real mailbox. It's just the From identity. Replies still route to the enquirer via the `Reply-To` header.
+- If you want to receive bounce notifications, configure a webhook in Resend → Webhooks (optional, low priority).
+
+---
+
+## 5. Future Enhancements (Not in Scope Now)
+
+These are deliberately deferred until there's a real need:
+
+- **Spam handling beyond honeypot:** add Cloudflare Turnstile or hCaptcha if bot submissions get noisy.
+- **Rate limiting:** Vercel has built-in protections, but if abused, add `upstash/ratelimit` keyed by IP.
+- **Enquiry-type routing:** add a "What's this about?" dropdown (Safari / Workshop / Prints / Collab) and route to different inboxes or use it as the email subject prefix.
+- **CRM sync:** push submissions into Kit as tagged subscribers, or into a Google Sheet via a webhook, so enquiries are searchable.
+- **Auto-acknowledgement email:** send a confirmation email to the enquirer so they know it landed.
+
+---
+
+## Files Touched
+
+- `components/ContactForm.tsx` (new)
+- `pages/api/contact.ts` (new)
+- `pages/contact.tsx` (modified)
+- `package.json` + `yarn.lock` (added `resend`)
+- `docs/contact-form-rollout.md` (this file)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "next-cloudinary": "4.9.0",
     "next-sitemap": "4.2.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "resend": "^6.12.4"
   },
   "devDependencies": {
     "@fontsource/playfair-display": "5.2.8",

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,0 +1,144 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Resend } from "resend";
+
+const TO_ADDRESSES = ["safaris@taranghirani.com", "tarang9211@gmail.com"];
+const FROM_ADDRESS =
+  process.env.CONTACT_FROM_ADDRESS ||
+  "Tarang Hirani Website <onboarding@resend.dev>";
+
+const MAX_LEN = {
+  name: 120,
+  email: 200,
+  phone: 40,
+  countryCode: 8,
+  message: 5000,
+};
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const { name, email, countryCode, phone, message } = req.body || {};
+
+  if (
+    typeof name !== "string" ||
+    typeof email !== "string" ||
+    typeof countryCode !== "string" ||
+    typeof phone !== "string" ||
+    typeof message !== "string"
+  ) {
+    return res.status(400).json({ error: "Missing required fields" });
+  }
+
+  const trimmed = {
+    name: name.trim(),
+    email: email.trim(),
+    countryCode: countryCode.trim(),
+    phone: phone.trim(),
+    message: message.trim(),
+  };
+
+  if (
+    !trimmed.name ||
+    !trimmed.email ||
+    !trimmed.phone ||
+    !trimmed.message ||
+    !trimmed.countryCode
+  ) {
+    return res.status(400).json({ error: "Please fill in every field" });
+  }
+
+  if (
+    trimmed.name.length > MAX_LEN.name ||
+    trimmed.email.length > MAX_LEN.email ||
+    trimmed.phone.length > MAX_LEN.phone ||
+    trimmed.countryCode.length > MAX_LEN.countryCode ||
+    trimmed.message.length > MAX_LEN.message
+  ) {
+    return res.status(400).json({ error: "One of your fields is too long" });
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed.email)) {
+    return res
+      .status(400)
+      .json({ error: "Please enter a valid email address" });
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.error("Missing RESEND_API_KEY env var");
+    return res.status(500).json({ error: "Server configuration error" });
+  }
+
+  const resend = new Resend(apiKey);
+
+  const fullPhone = `${trimmed.countryCode} ${trimmed.phone}`;
+  const subject = `New enquiry from ${trimmed.name}`;
+
+  const text = [
+    `New enquiry from ${trimmed.name}`,
+    "",
+    `Email:  ${trimmed.email}`,
+    `Phone:  ${fullPhone}`,
+    "",
+    "Message:",
+    trimmed.message,
+    "",
+    "—",
+    "Sent from the contact form on taranghirani.com",
+  ].join("\n");
+
+  const html = `<!doctype html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color:#080808; max-width:560px; margin:0 auto; padding:24px;">
+  <p style="font-size:11px; letter-spacing:0.2em; text-transform:uppercase; color:#C4956A; margin:0 0 16px;">New Enquiry</p>
+  <h1 style="font-size:22px; font-weight:600; margin:0 0 24px;">${escapeHtml(trimmed.name)}</h1>
+  <table style="width:100%; border-collapse:collapse; margin-bottom:24px;">
+    <tr>
+      <td style="padding:8px 0; color:#525252; font-size:13px; width:80px; vertical-align:top;">Email</td>
+      <td style="padding:8px 0; font-size:14px;"><a href="mailto:${escapeHtml(trimmed.email)}" style="color:#080808;">${escapeHtml(trimmed.email)}</a></td>
+    </tr>
+    <tr>
+      <td style="padding:8px 0; color:#525252; font-size:13px; vertical-align:top;">Phone</td>
+      <td style="padding:8px 0; font-size:14px;"><a href="tel:${escapeHtml(trimmed.countryCode + trimmed.phone.replace(/\s/g, ""))}" style="color:#080808;">${escapeHtml(fullPhone)}</a></td>
+    </tr>
+  </table>
+  <p style="font-size:11px; letter-spacing:0.2em; text-transform:uppercase; color:#525252; margin:0 0 8px;">Message</p>
+  <div style="font-size:15px; line-height:1.6; white-space:pre-wrap; padding:16px; background:#F5F5F3; border-left:2px solid #C4956A;">${escapeHtml(trimmed.message)}</div>
+  <p style="font-size:11px; color:#999; margin-top:24px;">Sent from the contact form on taranghirani.com</p>
+</body></html>`;
+
+  try {
+    const { error } = await resend.emails.send({
+      from: FROM_ADDRESS,
+      to: TO_ADDRESSES,
+      replyTo: trimmed.email,
+      subject,
+      text,
+      html,
+    });
+
+    if (error) {
+      console.error("Resend send error:", error);
+      return res.status(500).json({ error: "Failed to send message" });
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error("Resend request failed:", err);
+    return res.status(500).json({ error: "Failed to send message" });
+  }
+}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import FadeIn from "../components/FadeIn";
 import ContactLinks from "../components/ContactLinks";
+import ContactForm from "../components/ContactForm";
 
 export default function ContactPage() {
   return (
@@ -9,7 +10,7 @@ export default function ContactPage() {
         <title>Contact | Tarang Hirani</title>
         <meta
           name="description"
-          content="Get in touch with Tarang Hirani to enquire about wildlife safaris in India and Africa, prints, collaborations, or commissions. Call, WhatsApp, or email."
+          content="Get in touch with Tarang Hirani to enquire about wildlife safaris in India and Africa, prints, collaborations, or commissions. Send a message or reach out on WhatsApp."
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
@@ -26,13 +27,26 @@ export default function ContactPage() {
                 Let&apos;s talk.
               </h1>
               <p className="mt-6 text-base md:text-lg leading-relaxed text-white/60">
-                Whether you&apos;re planning a safari in India or Africa, looking
-                for prints, or want to collaborate, the fastest way to reach me
-                is on WhatsApp or email. I read every message.
+                Looking to learn photography or plan a photography focussed
+                experience? I read every message and reply within 48 hours.
               </p>
             </div>
 
             <div className="mt-14 md:mt-16">
+              <ContactForm />
+            </div>
+          </FadeIn>
+
+          <FadeIn delay={200}>
+            <div className="mt-20 md:mt-24 flex items-center justify-center gap-4">
+              <span className="h-px w-12 bg-white/10" />
+              <span className="text-[11px] text-white/30 uppercase tracking-[0.2em]">
+                Or reach out directly
+              </span>
+              <span className="h-px w-12 bg-white/10" />
+            </div>
+
+            <div className="mt-10 md:mt-12">
               <ContactLinks
                 theme="dark"
                 layout="stack"

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -15,7 +15,7 @@ export default function ContactPage() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
 
-      <section className="bg-charcoal min-h-screen pt-32 pb-24 md:pt-40 md:pb-32">
+      <section className="bg-paper min-h-screen pt-32 pb-24 md:pt-40 md:pb-32">
         <div className="mx-auto max-w-2xl px-6 md:px-12">
           <FadeIn>
             <div className="text-center">
@@ -23,32 +23,32 @@ export default function ContactPage() {
               <p className="mt-8 text-[11px] font-medium uppercase tracking-[0.2em] text-sage">
                 Get in Touch
               </p>
-              <h1 className="mt-4 font-display text-4xl md:text-5xl lg:text-6xl font-semibold text-parchment tracking-tight">
+              <h1 className="mt-4 font-display text-4xl md:text-5xl lg:text-6xl font-semibold text-charcoal tracking-tight">
                 Let&apos;s talk.
               </h1>
-              <p className="mt-6 text-base md:text-lg leading-relaxed text-white/60">
+              <p className="mt-6 text-base md:text-lg leading-relaxed text-smoke">
                 Looking to learn photography or plan a photography focussed
                 experience? I read every message and reply within 48 hours.
               </p>
             </div>
 
             <div className="mt-14 md:mt-16">
-              <ContactForm />
+              <ContactForm theme="light" />
             </div>
           </FadeIn>
 
           <FadeIn delay={200}>
             <div className="mt-20 md:mt-24 flex items-center justify-center gap-4">
-              <span className="h-px w-12 bg-white/10" />
-              <span className="text-[11px] text-white/30 uppercase tracking-[0.2em]">
+              <span className="h-px w-12 bg-charcoal/10" />
+              <span className="text-[11px] text-smoke uppercase tracking-[0.2em]">
                 Or reach out directly
               </span>
-              <span className="h-px w-12 bg-white/10" />
+              <span className="h-px w-12 bg-charcoal/10" />
             </div>
 
             <div className="mt-10 md:mt-12">
               <ContactLinks
-                theme="dark"
+                theme="light"
                 layout="stack"
                 showLabels
                 includeInstagram

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,6 +1599,11 @@
     fflate "^0.7.3"
     string.prototype.codepointat "^0.2.1"
 
+"@stablelib/base64@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
+  integrity sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==
+
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
   resolved "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz"
@@ -2557,6 +2562,11 @@ fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.8"
+
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"
@@ -3906,6 +3916,11 @@ pirates@^4.0.1:
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
 
+postal-mime@2.7.4:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/postal-mime/-/postal-mime-2.7.4.tgz#3718d1f188357ed86f906f1db8d4ca455efa4927"
+  integrity sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==
+
 postcss-import@15.1.0, postcss-import@^15.1.0:
   version "15.1.0"
   resolved "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz"
@@ -4178,6 +4193,14 @@ regjsparser@^0.12.0:
   dependencies:
     jsesc "~3.0.2"
 
+resend@^6.12.4:
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/resend/-/resend-6.12.4.tgz#37585aff359704f6434d529e6b84924f0786d86d"
+  integrity sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==
+  dependencies:
+    postal-mime "2.7.4"
+    standardwebhooks "1.0.0"
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
@@ -4410,6 +4433,14 @@ ssri@^9.0.0, ssri@^9.0.1:
   integrity sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==
   dependencies:
     minipass "^3.1.1"
+
+standardwebhooks@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz#5faa23ceacbf9accd344361101d9e3033b64324f"
+  integrity sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==
+  dependencies:
+    "@stablelib/base64" "^1.0.0"
+    fast-sha256 "^1.3.0"
 
 streamsearch@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary
- New `/contact` form (name, email, country code + phone, message) above the existing ContactLinks block.
- Submissions email to `safaris@taranghirani.com` and `tarang9211@gmail.com` via Resend, with `Reply-To` set to the enquirer.
- Per-field client validation with inline error messages, honeypot anti-spam, loading/success/error states styled to match the existing dark-mode aesthetic.
- Rollout plan (Resend signup, env vars, domain verification, smoke test) documented in `docs/contact-form-rollout.md`.

## Required before merging to prod
- [ ] Add `RESEND_API_KEY` to Vercel env vars (Production + Preview, marked Sensitive).
- [ ] Optional: verify `taranghirani.com` in Resend and set `CONTACT_FROM_ADDRESS` for a branded sender (see docs §4).

## Test plan
- [ ] Local: `yarn dev`, fill in `RESEND_API_KEY` in `.env.local`, submit a real enquiry from `/contact`, confirm both inboxes receive it within ~30s.
- [ ] Submit an empty form — confirm per-field validation messages appear in red under each field.
- [ ] Submit with an invalid email (`not-an-email`) — confirm only the email field flags the error.
- [ ] Click Reply in either inbox — confirm it addresses the enquirer's email, not Resend.
- [ ] On a Vercel preview deploy: repeat the happy-path submission test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)