### PR TITLE
About: vertical portrait crop

### DIFF
--- a/components/AboutMe.jsx
+++ b/components/AboutMe.jsx
@@ -2,7 +2,12 @@ import React from "react";
 import Image from "next/image";
 import { useInView } from "../lib/useInView";
 
-export default function AboutSection({ featuredImage }) {
+const PORTRAIT = {
+  url: "https://res.cloudinary.com/duiyn8wll/image/upload/f_auto,q_auto/db3b2405-9bec-4b5e-a88f-80c4032b321c_ukpumb",
+  alt: "Tarang Hirani in the field",
+};
+
+export default function AboutSection() {
   const { ref: textRef, visible: textVisible } = useInView(0.1);
   const { ref: imgRef, visible: imgVisible } = useInView();
 
@@ -16,10 +21,10 @@ export default function AboutSection({ featuredImage }) {
       <div className="py-24 md:py-32">
         <div className="mx-auto max-w-7xl px-6 md:px-12 lg:px-20">
           <div className="grid grid-cols-1 gap-8 lg:grid-cols-12 lg:gap-8">
-            {/* Text — left 5 columns */}
+            {/* Text — left 8 columns */}
             <div
               ref={textRef}
-              className={`lg:col-span-5 lg:pt-16 transition-all duration-700 delay-150 ${
+              className={`lg:col-span-8 transition-all duration-700 delay-150 ${
                 textVisible
                   ? "opacity-100 translate-y-0"
                   : "opacity-0 translate-y-8"
@@ -61,23 +66,25 @@ export default function AboutSection({ featuredImage }) {
               </p>
             </div>
 
-            {/* Image — right 7 columns, bleeds off right edge */}
+            {/* Image — right 4 columns, vertically centered, portrait crop */}
             <div
               ref={imgRef}
-              className={`lg:col-span-7 transition-all duration-700 ${
+              className={`lg:col-span-4 lg:self-center transition-all duration-700 ${
                 imgVisible
                   ? "opacity-100 translate-y-0"
                   : "opacity-0 translate-y-8"
               }`}
             >
-              <div className="lg:-mr-20 xl:-mr-32">
-                <Image
-                  src={featuredImage.url}
-                  alt={featuredImage.alt}
-                  width={900}
-                  height={1200}
-                  className="h-auto w-full rounded-xl lg:rounded-r-none lg:rounded-l-xl object-cover"
-                />
+              <div className="mx-auto max-w-sm lg:max-w-none lg:ml-auto lg:mr-0 lg:w-[320px] xl:w-[360px]">
+                <div className="relative aspect-[3/4] overflow-hidden rounded-xl">
+                  <Image
+                    src={PORTRAIT.url}
+                    alt={PORTRAIT.alt}
+                    fill
+                    sizes="(min-width: 1280px) 360px, (min-width: 1024px) 320px, 384px"
+                    className="object-cover object-center"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/lib/helpers/index.ts
+++ b/lib/helpers/index.ts
@@ -110,23 +110,3 @@ export async function listImages(limit = 20): Promise<GalleryImage[]> {
   }));
 }
 
-export interface FeaturedImage {
-  url: string;
-  alt: string;
-}
-
-export async function getFeaturedImage(): Promise<FeaturedImage | null> {
-  const { resources } = await cloudinary.search
-    .expression('metadata.featured="yes"')
-    .max_results(1)
-    .execute();
-
-  if (!resources.length) return null;
-
-  const img = resources[0];
-
-  return {
-    url: optimizeUrl(img.secure_url),
-    alt: img.context?.custom?.alt ?? "Featured image",
-  };
-}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,16 +7,14 @@ import Head from "next/head";
 
 import {
   getHeroImages,
-  getFeaturedImage,
   listImages,
   GalleryImage,
 } from "../lib/helpers";
 
 export async function getStaticProps() {
-  const [heroImages, carouselImages, featuredImage] = await Promise.all([
+  const [heroImages, carouselImages] = await Promise.all([
     getHeroImages(),
     listImages(20),
-    getFeaturedImage(),
   ]);
 
   return {
@@ -24,7 +22,6 @@ export async function getStaticProps() {
       heroDesktop: heroImages.desktop,
       heroMobile: heroImages.mobile,
       carouselImages,
-      featuredImage,
     },
     revalidate: 3600,
   };
@@ -34,7 +31,6 @@ export default function Home({
   heroDesktop,
   heroMobile,
   carouselImages,
-  featuredImage,
 }) {
   return (
     <div className="bg-charcoal text-parchment">
@@ -46,7 +42,7 @@ export default function Home({
       <SafariOffering />
       <EmailSignup variant="section" />
       <ImageCarousel images={carouselImages} />
-      <AboutMe featuredImage={featuredImage} />
+      <AboutMe />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Constrain the About-section portrait to a 3:4 vertical crop (~320–360px wide on desktop) instead of the wide bleed-off-right block
- Hardcode the portrait URL in `AboutMe` and remove the now-unused `getFeaturedImage` helper + prop threading from `pages/index.tsx`

## Test plan
- [ ] `yarn dev` → home page → About section renders a centered vertical portrait next to the text
- [ ] Mobile width: portrait centered, capped at `max-w-sm`
- [ ] Desktop (≥lg): portrait sits right of the text, vertically centered, no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)