### PR TITLE
Add tour-poster skill

### DIFF
--- a/.claude/skills/tour-poster/SKILL.md
+++ b/.claude/skills/tour-poster/SKILL.md
@@ -1,0 +1,254 @@
+Base directory for this skill: /Users/tarang/Documents/dev/taranghirani-website/.claude/skills/tour-poster
+
+You are a marketing designer for Tarang Hirani, a wildlife photographer based in India who runs guided wildlife tours and experiences.
+
+## Purpose
+
+Generate a marketing creative for a wildlife tour or experience from a single background photograph + a handful of fields. Every run produces three platform-named JPGs from the same inputs:
+
+| Internal format | Dimensions | Output suffix        | Destination                       |
+| --------------- | ---------- | -------------------- | --------------------------------- |
+| `story`         | 1080×1920  | `_instagram_story`   | Instagram Story + WhatsApp Status |
+| `post`          | 1080×1350  | `_instagram_post`    | Instagram feed                    |
+| `square`        | 2692×2692  | `_whatsapp`          | WhatsApp chat shareable (HD)      |
+
+Visual intent: Nat Geo editorial discipline (huge Playfair location, generous negative space, single sage hairline) wrapped around a real marketing block (struck-through original price, "now" price, progressive seat counter, contact line).
+
+## Setup
+
+The rendering script lives in the skill's base directory and runs via `npm run tour-poster`. Before first use:
+
+```bash
+cd /Users/tarang/Documents/dev/taranghirani-website
+npm install   # installs all dependencies, including the poster renderer
+```
+
+If the script fails on first run, check for missing system-level dependencies (Cairo/Pango for `canvas`, or `sharp`) — error messages will indicate which.
+
+## Brand Identity
+
+Tokens are defined in `docs/DESIGN.md` (relative to the website repo root: `/Users/tarang/Documents/dev/taranghirani-website/docs/DESIGN.md`). Do not introduce colors, fonts, or spacing tokens beyond what that file specifies. If the user asks to try a different accent color or typeface, discuss it but do not apply it to generated output without updating DESIGN.md first.
+
+- **Display font:** Playfair Display 700 (italic available) — location headline, tagline, subtitle
+- **Body font:** Source Sans 3 — eyebrows (500), body / pricing / dates / phone (700), handles (600)
+- **Colors:** charcoal `#080808`, parchment `#FFFFFF`, paper `#F5F5F3`, smoke `#525252`, sage `#C4956A`
+- Sage is the only accent — used for the discount eyebrow, available seat dots, hairline rule, and the website handle. Keep it under ~5% of any composition.
+
+## Input images
+
+Source photographs live in `.claude/skills/tour-poster/input/`. Drop the safari image into that folder before running.
+
+**Requirements:** JPG or PNG. Minimum dimensions are **1080 wide × 1920 tall** — *both* axes, not "longest edge" — because the Story format (1080×1920) is the most demanding crop and an image short on either dimension gets upscaled (soft). 1620×2880 or larger is comfortable; any modern camera (DSLR, mirrorless, recent phone) clears that trivially. The renderer cover-crops to each format's aspect ratio (9:16, 4:5, 1:1), so images with a clear central subject and breathing room on all sides work best. HEIC and TIFF are not supported.
+
+Image selection logic:
+
+- **Omit `--image`** — when the folder holds exactly one image, the script picks it automatically and logs the filename.
+- **Pass a bare filename** — e.g. `--image panna-tiger.jpg` resolves to `input/panna-tiger.jpg`.
+- **Pass an explicit path** — anything containing `/`, or starting with `.` / `~` / `/`, is treated as-is and bypasses `input/`.
+
+If the folder has zero images, the script errors with a clear "drop one in" message. If it has multiple, the script lists them and asks you to pick with `--image <filename>`.
+
+## Usage
+
+All commands run from the website repo root.
+
+```bash
+npm run tour-poster -- [--image <name-or-path>] --location <name> --dates <range> \
+  --seats-total <n> --seats-filled <n> --price <inr> --phone <num> [options]
+```
+
+### Parameters
+
+| Flag               | Description                                                                                | Default                |
+| ------------------- | ------------------------------------------------------------------------------------------ | ---------------------- |
+| `--image`           | Filename inside `input/`, or any explicit path. Omit when `input/` has exactly one image.  | auto-pick from `input/` |
+| `--location`        | Park / destination name. Becomes the large headline (required)                             | —                      |
+| `--dates`           | e.g. `Oct 21–25, 2026` (required; rendered uppercase)                                      | —                      |
+| `--seats-total`     | Total seats in the cohort. Integer. Required **unless `--seats-text` is passed**.          | —                      |
+| `--seats-filled`    | Seats already booked, `0..seats-total`. Integer. Required **unless `--seats-text` is passed**. | —                  |
+| `--seats-text`      | Free-text scarcity label rendered in place of the seat caption (e.g. `Limited spots`, `Invite only`, `By application`). When supplied, the dots indicator is suppressed and the numeric flags become optional — useful when the cohort size is intentionally vague. Cannot be combined with the numeric flags (a warning is logged if both are passed, and the text wins). | none |
+| `--price`           | Display price including currency and formatting, e.g. `₹89,999` or `INR 89,999` (required). Rendered as-is — the script does not add currency symbols or reformat. | —                      |
+| `--phone`           | Contact number, full international format (required)                                       | —                      |
+| `--price-original`  | Original price; renders struck-through above `--price`. Same format rules as `--price`.    | none                   |
+| `--discount-label`  | Eyebrow above the markdown stack (only used with `--price-original`)                       | `EARLY BIRD`           |
+| `--price-suffix`    | Suffix appended to `--price`                                                               | `/ PERSON`             |
+| `--eyebrow`         | Small uppercase label above the location (e.g. `WILDLIFE PHOTOGRAPHY · 5 DAYS`)            | none                   |
+| `--exclusivity`     | 3–4 word access tag, sage caps **bold** + tracked, sized to read at a glance — designed to be a high-prominence scarcity cue, not a footnote. Positioned **near the dates**: in vertical layout it sits just above the dates line; in horizontal layout it sits at the top of the dates column. (e.g. `Exclusive for PCL members`) | none                   |
+| `--tagline`         | Italic serif tagline near the top. **Renders on Post and Story only** — excluded from Square because the square frame doesn't have room for it above the location block. | none                   |
+| `--subtitle`        | One-line description below the location                                                    | none                   |
+| `--location-italic` | Render the location in Playfair italic                                                     | off                    |
+| `--instagram`       | Instagram handle (rendered in the footer)                                                  | `@tarang.hirani`       |
+| `--website`         | Website (rendered in the footer)                                                           | `taranghirani.com`     |
+| `--name`            | Override the `<slug>` portion of the output filename                                       | snake_case `--location` |
+| `--formats`         | Comma list of `story`, `post`, `square` to render                                          | `story,post,square`    |
+| `--layout`          | `vertical` (default — every line stacks down the left edge) or `horizontal` (price / seats / dates render as a three-column row separated by sage vertical hairlines; the Playfair location stays a vertical hero above) | `vertical`             |
+
+### Seat caption logic
+
+When `--seats-text` is supplied, the caption is the literal text (uppercased, sage, tracked) and no dots indicator is rendered. The seats column simply reads shorter than its neighbours in horizontal layout — the row's `alignItems: "center"` keeps the row visually balanced.
+
+Otherwise (numeric mode), the renderer derives the caption from `--seats-total` + `--seats-filled`:
+
+| Condition              | Caption                                  |
+| ---------------------- | ---------------------------------------- |
+| `filled === 0`         | `<total> SEATS OPEN`                     |
+| `filled === total`     | `FULLY BOOKED`                           |
+| `remaining === 1`      | `1 SEAT LEFT`                            |
+| Otherwise              | `<remaining> OF <total> SEATS REMAINING` |
+
+Dots: first `filled` circles in muted smoke (booked), remainder in sage (available). When fully booked, all dots are smoke.
+
+### Output
+
+Files are written to `.claude/skills/tour-poster/output/YYYY-MM-DD/`.
+
+Filename pattern:
+
+```
+tour_poster_tmh_<slug>_<platform>.jpg
+```
+
+- `tour_poster_tmh_` — fixed prefix (filter all generated files with `tour_poster_tmh_*`)
+- `<slug>` — snake_case `--location`, or `--name` if passed (e.g. `panna`, `bandhavgarh_national_park`)
+- `<platform>` — `instagram_story` | `instagram_post` | `whatsapp`
+
+Re-running with the same `--location` / `--name` overwrites — intentional for iteration.
+
+### Rendering quality (sharpness)
+
+The renderer is tuned for crisp type. These settings are deliberate — do not regress them unless the user explicitly asks for a smaller file size or faster render:
+
+- **Satori overlay rasterised at 2× supersampling.** `sharp(svg, { density: 144 })` then `resize(width, height, { kernel: "lanczos3" })`. This is what keeps the small caps and Playfair curves sharp; reverting to default 72 DPI noticeably softens type.
+- **JPEG output**: `quality: 96`, `chromaSubsampling: "4:4:4"`, `mozjpeg: true`. The 4:4:4 chroma is the standard fix for soft coloured text on JPEG — defaults (4:2:0) blur sage labels and price strikes.
+- **Input image minimum**: 1080 wide × 1920 tall. Both axes matter — a 2000×1500 landscape upscales for the Story canvas and prints soft. Recommend 1620×2880 (1.5×) or larger from any modern camera.
+
+If the user reports soft type and the input image meets the minimum, the next escalation is to bump `density` from 144 to 288 (4× supersample) in `renderOverlay`. Anything beyond 288 has diminishing returns and triples render time.
+
+If the user wants a noticeably smaller file size and is willing to trade some crispness, lower `density` toward 96 or drop `mozjpeg`.
+
+### Type ramp
+
+The current font sizes per element per format, in pixels at the native canvas (1080w × 1350h Post / 1080×1920 Story / **2692×2692 Square** — WhatsApp HD spec). Square runs ~2.5× the values of Post/Story because it renders at 2.5× canvas resolution — proportions are the same, pixels are larger. The **location heading** is the lone hero and roughly 3× the next-largest element; the **pricing "now" price** is the second focal point. **Exclusivity** sits one step above the pricing eyebrow so the access claim out-shouts the discount label.
+
+These values live in `scripts/generate-tour-poster.ts` — when tuning, update the script and mirror the change here so the two stay in sync.
+
+#### Hero block (top of canvas)
+
+| Element | Post | Story | Square |
+| ------- | ---- | ----- | ------ |
+| Tagline (Playfair italic 700, white, centred) | 34 | 42 | — *(Square has no tagline)* |
+| Eyebrow (Source Sans 500, sage caps, tracked) | 18 | 22 | 16 |
+| **Location (Playfair 700, white) — the hero, do not bump without explicit ask** | **156** | **192** | **112** |
+| Subtitle (Playfair italic 700, paper) | 36 | 44 | 30 |
+
+#### Marketing block — vertical layout
+
+| Element | Post | Story | Square |
+| ------- | ---- | ----- | ------ |
+| Pricing eyebrow (`EARLY BIRD`, Source Sans 500, sage caps) | 18 | 22 | 16 |
+| Pricing struck (Source Sans 400, smoke, line-through) | 28 | 32 | 24 |
+| Pricing "now" (Source Sans 700, white, tracked) | 40 | 48 | 36 |
+| Pricing suffix (`/ PERSON`) — inline with price | 40 | 48 | 36 |
+| Seat dots (diameter) | 15 | 16 | 13 |
+| Seat caption (Source Sans 700, sage caps) | 28 | 30 | 24 |
+| **Exclusivity** (Source Sans 700, sage caps, bold — above dates) | **22** | **24** | **18** |
+| Dates (Source Sans 700, white, tracked) | 32 | 36 | 28 |
+
+#### Marketing block — horizontal layout (`tripDetailsRow`)
+
+| Element | Post | Story | Square |
+| ------- | ---- | ----- | ------ |
+| Pricing eyebrow | 16 | 20 | 15 |
+| Pricing struck | 24 | 28 | 22 |
+| Pricing "now" | 38 | 42 | 32 |
+| Pricing suffix (separate line, Source Sans 500, paper) — *auto, round(now × 0.55)* | 21 | 23 | 18 |
+| Seat dots (diameter) — *suppressed when `--seats-text` is set* | 14 | 16 | 13 |
+| Seat caption | 24 | 26 | 22 |
+| **Exclusivity** (in dates column, Source Sans 700, sage caps) | **22** | **24** | **18** |
+| Dates (two-line stack) | 28 | 30 | 26 |
+| Row height (visual frame for vertical centring + dividers) | 156 | 172 | 128 |
+
+#### Footer (below sage hairline)
+
+| Element | Post | Story | Square |
+| ------- | ---- | ----- | ------ |
+| Phone line (Source Sans 700, white, tracked) | 34 | 40 | 30 |
+| Handles `@tarang.hirani · taranghirani.com` (Source Sans 600, sage, tracked) | 26 | 28 | 22 |
+
+#### Editing rules
+
+- The location heading is fixed by design — don't change it without an explicit user ask.
+- Bumps to other elements should keep the **vertical-mode "now" price** as the second-largest element on each format (so the eye reads location → price first).
+- Horizontal-mode sizes run ~10–15% smaller than vertical to fit three columns at equal width.
+- Pricing suffix in horizontal mode is computed automatically from the "now" size (`round(now × 0.55)`) — don't override unless you have a specific reason.
+
+## Task
+
+When the user asks to create a marketing creative for a wildlife tour:
+
+1. **Check `input/` first.** List `.claude/skills/tour-poster/input/`.
+   - If exactly one image: note it inline ("using `<filename>`") and proceed.
+   - If multiple images: ask inline, in prose, which one to use.
+   - If empty: ask inline whether they're about to drop one in, or want to pass an explicit path.
+
+2. **Collect all fields before generating.** Gather everything — required and optional — so the first render is as close to final as possible. Present what you already know (from the conversation or from memory of prior runs) and ask for the rest. Group the ask into two passes:
+
+   **Pass 1 — Core details** (required):
+   `--location`, `--dates`, **either** (`--seats-total` + `--seats-filled`) **or** `--seats-text` (a free-text scarcity label like `Limited spots` when the cohort size is intentionally vague), `--price`, `--phone`
+
+   **Pass 2 — Creative direction** (optional, but ask before running):
+   `--eyebrow`, `--tagline`, `--subtitle`, `--exclusivity`, `--price-original` + `--discount-label`, `--price-suffix`, `--location-italic`, `--formats`
+
+   For pass 2, briefly describe what each option does so the user can decide without needing to reference the parameter table. For example: "Do you want an eyebrow line above the location — something like `WILDLIFE PHOTOGRAPHY · 5 DAYS`? A tagline in italic serif? A subtitle below the location name?"
+
+   If the user says "no extras" or "just the basics," skip pass 2 and run with defaults. Don't ask again on re-runs unless they bring up a new option.
+
+3. **Run the script** from the website repo root. If the script exits with a non-zero code, show the full stderr output and diagnose the issue before re-running. Common failures: missing fonts (install Playfair Display / Source Sans 3 system-wide or point to local `.ttf` files), corrupt or undersized input image, missing npm dependencies (`npm install`).
+
+4. **Review the outputs yourself.** Open each generated JPG and check for:
+   - **Text overflow or cramping** — location name, subtitle, or eyebrow running into edges or overlapping other elements.
+   - **Image crop** — key subject cut off or awkwardly placed in any of the three aspect ratios (9:16, 4:5, 1:1).
+   - **Readability** — text sitting on a busy area of the photograph with insufficient contrast.
+   - **Data correctness** — seat count, price, dates, and phone number all match what was passed in.
+
+   If anything looks off, flag it to the user with a specific fix (e.g. "the location overflows on the Square — I'd suggest shortening to 'Bandhavgarh' or dropping the subtitle") rather than silently presenting a broken output.
+
+5. **Present all three output files** so the user can confirm. Show the file paths and display the images.
+
+6. If they request changes, re-run with adjusted flags. Re-runs overwrite the prior outputs by design.
+
+### Text overflow
+
+The renderer uses fixed font sizes — it does not auto-shrink text to fit. If the location name, subtitle, or eyebrow overflows or looks cramped, shorten the copy in the flags rather than expecting the layout to adapt. Strategies: abbreviate the location (e.g. "Bandhavgarh" instead of "Bandhavgarh National Park"), drop `--subtitle` or `--eyebrow` to free vertical space, or split a long eyebrow across fewer words.
+
+### Iteration examples
+
+User says "two seats just got booked":
+→ Re-run with `--seats-filled` bumped by 2.
+
+User says "don't show a seat count, just say `Limited spots`" (or "Invite only", "By application", etc.):
+→ Re-run with `--seats-text "Limited spots"` and drop the `--seats-total` / `--seats-filled` flags. Dots disappear; the text becomes the caption.
+
+User says "show a higher original price":
+→ Re-run with `--price-original "₹1,09,999"`.
+
+User says "drop the early-bird label":
+→ Re-run without `--price-original` (the eyebrow + struck row vanish) — or pass `--discount-label " "` to keep the strike but blank the label.
+
+User says "just give me the story":
+→ Re-run with `--formats story`.
+
+User says "make it feel more editorial":
+→ Add `--location-italic`, drop `--subtitle`.
+
+User says "the location looks crowded":
+→ Shorten `--location`, or drop `--eyebrow` / `--subtitle` to give it room.
+
+User says "use the other image":
+→ List `input/`, ask which one, re-run with `--image <filename>`.
+
+User says "the marketing block feels long" or "spread the details out":
+→ Re-run with `--layout horizontal` — price / seats / dates render as a three-column row instead of stacking vertically.
+
+User says "why isn't my tagline on the WhatsApp version?":
+→ Explain that `--tagline` only renders on Story and Post formats — the Square (1080×1080) layout doesn't have room for it.

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 /.claude/skills/social-carousel/output
 /.claude/skills/social-slide/output
 /.claude/skills/social-slide/input
+/.claude/skills/tour-poster/input
+/.claude/skills/tour-poster/output
 
 # debug
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "deploy": "yarn build && yarn export",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "carousel": "tsx scripts/generate-carousel.ts",
-    "slide": "tsx scripts/generate-slide.ts"
+    "slide": "tsx scripts/generate-slide.ts",
+    "tour-poster": "tsx scripts/generate-tour-poster.ts"
   },
   "engines": {
     "node": "22.x"

--- a/scripts/generate-tour-poster.ts
+++ b/scripts/generate-tour-poster.ts
@@ -1,0 +1,1405 @@
+import satori from "satori";
+import sharp from "sharp";
+import * as fs from "fs/promises";
+import { readdirSync, existsSync } from "fs";
+import * as path from "path";
+
+const C = {
+  charcoal: "#080808",
+  paper: "#F5F5F3",
+  smoke: "#525252",
+  sage: "#C4956A",
+  white: "#FFFFFF",
+};
+
+type Format = "post" | "story" | "square";
+
+const DIMS: Record<Format, { width: number; height: number }> = {
+  post: { width: 1080, height: 1350 },
+  story: { width: 1080, height: 1920 },
+  square: { width: 2692, height: 2692 },
+};
+
+const FONTS_DIR = path.join(process.cwd(), "node_modules");
+const SKILL_DIR = path.join(
+  process.cwd(),
+  ".claude",
+  "skills",
+  "tour-poster",
+);
+const INPUT_DIR = path.join(SKILL_DIR, "input");
+const OUTPUT_ROOT = path.join(SKILL_DIR, "output");
+
+const PLATFORM_SUFFIX: Record<Format, string> = {
+  story: "instagram_story",
+  post: "instagram_post",
+  square: "whatsapp",
+};
+
+const IMAGE_EXT = /\.(jpe?g|png|webp)$/i;
+
+type Args = {
+  image: string;
+  location: string;
+  dates: string;
+  seatsTotal: number;
+  seatsFilled: number;
+  seatsText: string | null;
+  price: string;
+  phone: string;
+  priceOriginal: string | null;
+  discountLabel: string;
+  priceSuffix: string;
+  eyebrow: string | null;
+  exclusivity: string | null;
+  tagline: string | null;
+  subtitle: string | null;
+  locationItalic: boolean;
+  instagram: string;
+  website: string;
+  name: string;
+  formats: Format[];
+  layout: "vertical" | "horizontal";
+};
+
+function flag(name: string): string | null {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) return null;
+  const val = process.argv[idx + 1];
+  if (!val || val.startsWith("--")) return null;
+  return val;
+}
+
+function boolFlag(name: string): boolean {
+  return process.argv.indexOf(`--${name}`) !== -1;
+}
+
+function required(name: string): string {
+  const v = flag(name);
+  if (!v) {
+    console.error(`Missing required --${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function snakeify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+function resolveImage(raw: string | null): string {
+  if (raw === null) {
+    if (!existsSync(INPUT_DIR)) {
+      console.error(
+        `No images in ${path.relative(process.cwd(), INPUT_DIR)}/ — directory does not exist. Drop one in and re-run, or pass --image <path>.`,
+      );
+      process.exit(1);
+    }
+    const candidates = readdirSync(INPUT_DIR)
+      .filter((f) => IMAGE_EXT.test(f))
+      .sort();
+    if (candidates.length === 0) {
+      console.error(
+        `No images in ${path.relative(process.cwd(), INPUT_DIR)}/. Drop one in and re-run, or pass --image <path>.`,
+      );
+      process.exit(1);
+    }
+    if (candidates.length > 1) {
+      console.error(
+        `Multiple images in ${path.relative(process.cwd(), INPUT_DIR)}/: ${candidates.join(", ")}.\nPass --image <filename> to pick one.`,
+      );
+      process.exit(1);
+    }
+    const picked = path.join(INPUT_DIR, candidates[0]);
+    console.log(`Using ${candidates[0]} from input/`);
+    return picked;
+  }
+
+  const looksLikePath =
+    raw.includes("/") ||
+    raw.startsWith(".") ||
+    raw.startsWith("~") ||
+    raw.startsWith("/");
+
+  if (looksLikePath) {
+    if (!existsSync(raw)) {
+      console.error(`--image path does not exist: ${raw}`);
+      process.exit(1);
+    }
+    return raw;
+  }
+
+  const inInputDir = path.join(INPUT_DIR, raw);
+  if (existsSync(inInputDir)) return inInputDir;
+
+  if (existsSync(raw)) return raw;
+
+  console.error(
+    `Image not found.\n  Tried: ${path.relative(process.cwd(), inInputDir)}\n  Tried: ${raw}`,
+  );
+  process.exit(1);
+}
+
+function parseArgs(): Args {
+  const location = required("location");
+  const seatsText = flag("seats-text");
+  const seatsTotalRaw = flag("seats-total");
+  const seatsFilledRaw = flag("seats-filled");
+
+  let seatsTotal = 0;
+  let seatsFilled = 0;
+
+  if (seatsText) {
+    if (seatsTotalRaw || seatsFilledRaw) {
+      console.warn(
+        "Both --seats-text and numeric --seats-* flags supplied; using --seats-text (dots indicator suppressed).",
+      );
+    }
+  } else {
+    if (!seatsTotalRaw || !seatsFilledRaw) {
+      console.error(
+        "Provide either --seats-text \"<label>\" OR both --seats-total + --seats-filled (integers).",
+      );
+      process.exit(1);
+    }
+    seatsTotal = parseInt(seatsTotalRaw, 10);
+    seatsFilled = parseInt(seatsFilledRaw, 10);
+    if (
+      Number.isNaN(seatsTotal) ||
+      Number.isNaN(seatsFilled) ||
+      seatsFilled < 0 ||
+      seatsFilled > seatsTotal ||
+      seatsTotal < 1
+    ) {
+      console.error(
+        "--seats-total must be a positive integer; --seats-filled must be 0..seats-total",
+      );
+      process.exit(1);
+    }
+  }
+
+  const formatsRaw = flag("formats") ?? "story,post,square";
+  const formats = formatsRaw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(
+      (s): s is Format => s === "post" || s === "story" || s === "square",
+    );
+
+  if (formats.length === 0) {
+    console.error("--formats must contain at least one of story|post|square");
+    process.exit(1);
+  }
+
+  const layoutRaw = (flag("layout") ?? "vertical").toLowerCase();
+  if (layoutRaw !== "vertical" && layoutRaw !== "horizontal") {
+    console.error("--layout must be 'vertical' or 'horizontal'");
+    process.exit(1);
+  }
+  const layout = layoutRaw as "vertical" | "horizontal";
+
+  return {
+    image: resolveImage(flag("image")),
+    location,
+    dates: required("dates"),
+    seatsTotal,
+    seatsFilled,
+    seatsText,
+    price: required("price"),
+    phone: required("phone"),
+    priceOriginal: flag("price-original"),
+    discountLabel: flag("discount-label") ?? "EARLY BIRD",
+    priceSuffix: flag("price-suffix") ?? "/ PERSON",
+    eyebrow: flag("eyebrow"),
+    exclusivity: flag("exclusivity"),
+    tagline: flag("tagline"),
+    subtitle: flag("subtitle"),
+    locationItalic: boolFlag("location-italic"),
+    instagram: flag("instagram") ?? "@tarang.hirani",
+    website: flag("website") ?? "taranghirani.com",
+    name: snakeify(flag("name") ?? location),
+    formats,
+    layout,
+  };
+}
+
+async function loadFonts() {
+  const [
+    playfairBold,
+    playfairBoldItalic,
+    sourceSansRegular,
+    sourceSansMedium,
+    sourceSansSemiBold,
+    sourceSansBold,
+  ] = await Promise.all([
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/playfair-display/files/playfair-display-latin-700-normal.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/playfair-display/files/playfair-display-latin-700-italic.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/source-sans-3/files/source-sans-3-latin-400-normal.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/source-sans-3/files/source-sans-3-latin-500-normal.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/source-sans-3/files/source-sans-3-latin-600-normal.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/source-sans-3/files/source-sans-3-latin-700-normal.woff",
+      ),
+    ),
+  ]);
+
+  return [
+    {
+      name: "Playfair Display",
+      data: playfairBold.buffer as ArrayBuffer,
+      weight: 700 as const,
+      style: "normal" as const,
+    },
+    {
+      name: "Playfair Display",
+      data: playfairBoldItalic.buffer as ArrayBuffer,
+      weight: 700 as const,
+      style: "italic" as const,
+    },
+    {
+      name: "Source Sans 3",
+      data: sourceSansRegular.buffer as ArrayBuffer,
+      weight: 400 as const,
+      style: "normal" as const,
+    },
+    {
+      name: "Source Sans 3",
+      data: sourceSansMedium.buffer as ArrayBuffer,
+      weight: 500 as const,
+      style: "normal" as const,
+    },
+    {
+      name: "Source Sans 3",
+      data: sourceSansSemiBold.buffer as ArrayBuffer,
+      weight: 600 as const,
+      style: "normal" as const,
+    },
+    {
+      name: "Source Sans 3",
+      data: sourceSansBold.buffer as ArrayBuffer,
+      weight: 700 as const,
+      style: "normal" as const,
+    },
+  ];
+}
+
+function vignetteSvg(format: Format, width: number, height: number): Buffer {
+  let topStops: string;
+  let bottomStops: string;
+  if (format === "story") {
+    topStops = `
+      <stop offset="0%" stop-color="rgba(8,8,8,0.65)"/>
+      <stop offset="10%" stop-color="rgba(8,8,8,0.35)"/>
+      <stop offset="20%" stop-color="rgba(8,8,8,0.0)"/>
+    `;
+    bottomStops = `
+      <stop offset="0%" stop-color="rgba(8,8,8,0.92)"/>
+      <stop offset="40%" stop-color="rgba(8,8,8,0.55)"/>
+      <stop offset="65%" stop-color="rgba(8,8,8,0.0)"/>
+    `;
+  } else if (format === "square") {
+    topStops = `
+      <stop offset="0%" stop-color="rgba(8,8,8,0.55)"/>
+      <stop offset="20%" stop-color="rgba(8,8,8,0.0)"/>
+    `;
+    bottomStops = `
+      <stop offset="0%" stop-color="rgba(8,8,8,0.92)"/>
+      <stop offset="50%" stop-color="rgba(8,8,8,0.45)"/>
+      <stop offset="75%" stop-color="rgba(8,8,8,0.0)"/>
+    `;
+  } else {
+    topStops = `
+      <stop offset="0%" stop-color="rgba(8,8,8,0.80)"/>
+      <stop offset="14%" stop-color="rgba(8,8,8,0.45)"/>
+      <stop offset="25%" stop-color="rgba(8,8,8,0.0)"/>
+    `;
+    bottomStops = `
+      <stop offset="0%" stop-color="rgba(8,8,8,0.92)"/>
+      <stop offset="40%" stop-color="rgba(8,8,8,0.55)"/>
+      <stop offset="60%" stop-color="rgba(8,8,8,0.0)"/>
+    `;
+  }
+  return Buffer.from(
+    `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="topShade" x1="0" y1="0" x2="0" y2="1">${topStops}</linearGradient>
+        <linearGradient id="bottomShade" x1="0" y1="1" x2="0" y2="0">${bottomStops}</linearGradient>
+      </defs>
+      <rect width="100%" height="100%" fill="url(#topShade)"/>
+      <rect width="100%" height="100%" fill="url(#bottomShade)"/>
+    </svg>`,
+  );
+}
+
+async function buildBackground(
+  imagePath: string,
+  width: number,
+  height: number,
+  format: Format,
+): Promise<Buffer> {
+  const imgBuffer = await fs.readFile(imagePath);
+  const cover = await sharp(imgBuffer)
+    .resize(width, height, { fit: "cover", position: "centre" })
+    .png()
+    .toBuffer();
+
+  return sharp(cover)
+    .composite([{ input: vignetteSvg(format, width, height), blend: "over" }])
+    .png()
+    .toBuffer();
+}
+
+function seatCaption(filled: number, total: number): string {
+  const remaining = total - filled;
+  if (filled === total) return "FULLY BOOKED";
+  if (filled === 0) return `${total} SEATS OPEN`;
+  if (remaining === 1) return "1 SEAT LEFT";
+  return `${remaining} OF ${total} SEATS REMAINING`;
+}
+
+function dotsRow(
+  total: number,
+  filled: number,
+  size: number = 12,
+  gap: number = 8,
+) {
+  const dots: any[] = [];
+  for (let i = 0; i < total; i++) {
+    const isFilled = i < filled;
+    dots.push({
+      type: "div",
+      props: {
+        style: {
+          width: size,
+          height: size,
+          borderRadius: size,
+          backgroundColor: isFilled ? "rgba(82,82,82,0.6)" : C.sage,
+        },
+      },
+    });
+  }
+  return {
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        flexDirection: "row" as const,
+        alignItems: "center",
+        gap,
+      },
+      children: dots,
+    },
+  };
+}
+
+function pricingNode(
+  args: Args,
+  sizes: { eyebrow: number; struck: number; price: number },
+  align: "flex-start" | "center" = "flex-start",
+  stackedSuffix: boolean = false,
+) {
+  const children: any[] = [];
+  if (args.priceOriginal) {
+    children.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 500,
+          fontSize: sizes.eyebrow,
+          color: C.sage,
+          letterSpacing: Math.max(2, Math.round(sizes.eyebrow * 0.2)),
+        },
+        children: args.discountLabel.toUpperCase(),
+      },
+    });
+    children.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 400,
+          fontSize: sizes.struck,
+          color: C.white,
+          letterSpacing: 3,
+          textDecoration: "line-through",
+          marginTop: 6,
+        },
+        children: args.priceOriginal.toUpperCase(),
+      },
+    });
+  }
+  children.push({
+    type: "span",
+    props: {
+      style: {
+        fontFamily: "Source Sans 3",
+        fontWeight: 700,
+        fontSize: sizes.price,
+        color: C.white,
+        letterSpacing: 4,
+        marginTop: args.priceOriginal ? 4 : 0,
+      },
+      children: stackedSuffix
+        ? args.price.toUpperCase()
+        : `${args.price} ${args.priceSuffix}`.toUpperCase(),
+    },
+  });
+  if (stackedSuffix && args.priceSuffix) {
+    children.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 500,
+          fontSize: Math.round(sizes.price * 0.55),
+          color: C.paper,
+          letterSpacing: 3,
+          marginTop: 4,
+        },
+        children: args.priceSuffix.toUpperCase(),
+      },
+    });
+  }
+  return {
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: align,
+      },
+      children,
+    },
+  };
+}
+
+function seatsHorizontal(args: Args, dotSize: number, captionSize: number) {
+  if (args.seatsText) {
+    return {
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: captionSize,
+          color: C.sage,
+          letterSpacing: 4,
+        },
+        children: args.seatsText.toUpperCase(),
+      },
+    };
+  }
+  return {
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        flexDirection: "row" as const,
+        alignItems: "center",
+        gap: 16,
+      },
+      children: [
+        dotsRow(args.seatsTotal, args.seatsFilled, dotSize),
+        {
+          type: "span",
+          props: {
+            style: {
+              fontFamily: "Source Sans 3",
+              fontWeight: 700,
+              fontSize: captionSize,
+              color: C.sage,
+              letterSpacing: 4,
+            },
+            children: seatCaption(args.seatsFilled, args.seatsTotal),
+          },
+        },
+      ],
+    },
+  };
+}
+
+function seatsStacked(args: Args, dotSize: number, captionSize: number) {
+  if (args.seatsText) {
+    return {
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: captionSize,
+          color: C.sage,
+          letterSpacing: 4,
+          textAlign: "center" as const,
+        },
+        children: args.seatsText.toUpperCase(),
+      },
+    };
+  }
+  return {
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: "center",
+        gap: 10,
+      },
+      children: [
+        dotsRow(args.seatsTotal, args.seatsFilled, dotSize, 10),
+        {
+          type: "span",
+          props: {
+            style: {
+              fontFamily: "Source Sans 3",
+              fontWeight: 700,
+              fontSize: captionSize,
+              color: C.sage,
+              letterSpacing: 4,
+            },
+            children: seatCaption(args.seatsFilled, args.seatsTotal),
+          },
+        },
+      ],
+    },
+  };
+}
+
+function footerBlock(
+  args: Args,
+  phoneSize: number,
+  handleSize: number,
+  align: "flex-start" | "center" = "flex-start",
+) {
+  return {
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: align,
+        width: "100%",
+      },
+      children: [
+        {
+          type: "div",
+          props: {
+            style: {
+              width: "100%",
+              height: 1,
+              backgroundColor: C.sage,
+              opacity: 0.7,
+            },
+          },
+        },
+        {
+          type: "span",
+          props: {
+            style: {
+              fontFamily: "Source Sans 3",
+              fontWeight: 700,
+              fontSize: phoneSize,
+              color: C.white,
+              letterSpacing: 2,
+              marginTop: 18,
+            },
+            children: `CALL ${args.phone}`,
+          },
+        },
+        {
+          type: "span",
+          props: {
+            style: {
+              fontFamily: "Source Sans 3",
+              fontWeight: 600,
+              fontSize: handleSize,
+              color: C.sage,
+              letterSpacing: 3,
+              marginTop: 6,
+            },
+            children: `${args.instagram}  ·  ${args.website}`,
+          },
+        },
+      ],
+    },
+  };
+}
+
+function topHookBlock(
+  args: Args,
+  opts: {
+    taglineFont: number;
+    rule: number;
+    top: number;
+    left: number;
+    right: number;
+    includeTagline?: boolean;
+  },
+) {
+  const tagline = (opts.includeTagline ?? true) ? args.tagline : null;
+  if (!tagline) return null;
+
+  return {
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        top: opts.top,
+        left: opts.left,
+        right: opts.right,
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: "center",
+      },
+      children: [
+        {
+          type: "span",
+          props: {
+            style: {
+              fontFamily: "Playfair Display",
+              fontWeight: 700,
+              fontStyle: "italic",
+              fontSize: opts.taglineFont,
+              color: C.white,
+              letterSpacing: 0.5,
+              textAlign: "center" as const,
+              lineHeight: 1.25,
+            },
+            children: tagline,
+          },
+        },
+        {
+          type: "div",
+          props: {
+            style: {
+              width: opts.rule,
+              height: 1,
+              backgroundColor: C.sage,
+              marginTop: 14,
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+function tripDetailsRow(
+  args: Args,
+  opts: {
+    priceSizes: { eyebrow: number; struck: number; price: number };
+    seatsDot: number;
+    seatsCaption: number;
+    datesSize: number;
+    rowHeight: number;
+    width: number;
+    exclusivityFont: number;
+  },
+) {
+  const datesText = args.dates.toUpperCase();
+  const lastComma = datesText.lastIndexOf(",");
+  const datesLines =
+    lastComma >= 0
+      ? [datesText.slice(0, lastComma).trim(), datesText.slice(lastComma + 1).trim()]
+      : [datesText];
+
+  const datesColumnChildren: any[] = [];
+  if (args.exclusivity) {
+    datesColumnChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: opts.exclusivityFont,
+          color: C.sage,
+          letterSpacing: Math.max(2, Math.round(opts.exclusivityFont * 0.22)),
+          marginBottom: 10,
+          lineHeight: 1.15,
+        },
+        children: args.exclusivity.toUpperCase(),
+      },
+    });
+  }
+  datesLines.forEach((line, i) => {
+    datesColumnChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: opts.datesSize,
+          color: C.white,
+          letterSpacing: 4,
+          lineHeight: 1.1,
+          marginTop: i === 0 ? 0 : 6,
+        },
+        children: line,
+      },
+    });
+  });
+
+  const divider = {
+    type: "div",
+    props: {
+      style: {
+        width: 1,
+        height: opts.rowHeight,
+        backgroundColor: C.sage,
+        opacity: 0.7,
+      },
+    },
+  };
+
+  const column = (
+    children: any[],
+    align: "flex-start" | "center",
+    paddingLeft = 16,
+    paddingRight = 16,
+  ) => ({
+    type: "div",
+    props: {
+      style: {
+        flexGrow: 1,
+        flexBasis: 0,
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: align,
+        justifyContent: "flex-start" as const,
+        paddingLeft,
+        paddingRight,
+      },
+      children,
+    },
+  });
+
+  return {
+    type: "div",
+    props: {
+      style: {
+        width: opts.width,
+        display: "flex",
+        flexDirection: "row" as const,
+        alignItems: "center" as const,
+      },
+      children: [
+        column([pricingNode(args, opts.priceSizes, "flex-start", true)], "flex-start", 0, 16),
+        divider,
+        column([seatsStacked(args, opts.seatsDot, opts.seatsCaption)], "center"),
+        divider,
+        column(datesColumnChildren, "flex-start", 16, 0),
+      ],
+    },
+  };
+}
+
+function exclusivitySpan(
+  text: string,
+  size: number,
+  align: "flex-start" | "center" = "flex-start",
+  marginTop: number,
+) {
+  return {
+    type: "span",
+    props: {
+      style: {
+        fontFamily: "Source Sans 3",
+        fontWeight: 700,
+        fontSize: size,
+        color: C.sage,
+        letterSpacing: Math.max(2, Math.round(size * 0.22)),
+        marginTop,
+        textAlign: align === "center" ? ("center" as const) : ("left" as const),
+        alignSelf: align,
+      },
+      children: text.toUpperCase(),
+    },
+  };
+}
+
+function buildPostJsx(args: Args) {
+  const { width: W, height: H } = DIMS.post;
+
+  const containerChildren: any[] = [];
+
+  const topHook = topHookBlock(args, {
+    taglineFont: 34,
+    rule: 48,
+    top: 80,
+    left: 76,
+    right: 76,
+  });
+  if (topHook) containerChildren.push(topHook);
+
+  const contentChildren: any[] = [];
+  if (args.eyebrow) {
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 500,
+          fontSize: 18,
+          color: C.sage,
+          letterSpacing: 3,
+          marginBottom: 14,
+        },
+        children: args.eyebrow.toUpperCase(),
+      },
+    });
+  }
+  contentChildren.push({
+    type: "span",
+    props: {
+      style: {
+        fontFamily: "Playfair Display",
+        fontWeight: 700,
+        fontStyle: args.locationItalic ? "italic" : "normal",
+        fontSize: 156,
+        color: C.white,
+        lineHeight: 1.0,
+      },
+      children: args.location,
+    },
+  });
+  if (args.subtitle) {
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Playfair Display",
+          fontWeight: 700,
+          fontStyle: "italic",
+          fontSize: 36,
+          color: C.paper,
+          lineHeight: 1.2,
+          marginTop: 6,
+        },
+        children: args.subtitle,
+      },
+    });
+  }
+  if (args.layout === "horizontal") {
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: {
+          marginTop: 30,
+          display: "flex",
+          width: "100%",
+        },
+        children: [
+          tripDetailsRow(args, {
+            priceSizes: { eyebrow: 16, struck: 24, price: 38 },
+            seatsDot: 14,
+            seatsCaption: 24,
+            datesSize: 28,
+            rowHeight: 156,
+            width: 928,
+            exclusivityFont: 22,
+          }),
+        ],
+      },
+    });
+  } else {
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: { marginTop: 26, display: "flex" },
+        children: [pricingNode(args, { eyebrow: 18, struck: 28, price: 40 })],
+      },
+    });
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: { marginTop: 22, display: "flex" },
+        children: [seatsHorizontal(args, 15, 28)],
+      },
+    });
+    if (args.exclusivity) {
+      contentChildren.push(
+        exclusivitySpan(args.exclusivity, 22, "flex-start", 22),
+      );
+    }
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: 32,
+          color: C.white,
+          letterSpacing: 4,
+          marginTop: args.exclusivity ? 10 : 18,
+        },
+        children: args.dates.toUpperCase(),
+      },
+    });
+  }
+
+  containerChildren.push({
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        left: 76,
+        right: 76,
+        bottom: 280,
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: "flex-start",
+      },
+      children: contentChildren,
+    },
+  });
+
+  containerChildren.push({
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        left: 76,
+        right: 76,
+        bottom: 130,
+        display: "flex",
+      },
+      children: [footerBlock(args, 34, 26, "flex-start")],
+    },
+  });
+
+  return {
+    type: "div",
+    props: {
+      style: {
+        width: W,
+        height: H,
+        display: "flex",
+        flexDirection: "column" as const,
+        position: "relative" as const,
+        fontFamily: "Source Sans 3",
+      },
+      children: containerChildren,
+    },
+  };
+}
+
+function buildStoryJsx(args: Args) {
+  const { width: W, height: H } = DIMS.story;
+
+  const containerChildren: any[] = [];
+
+  const topHook = topHookBlock(args, {
+    taglineFont: 42,
+    rule: 64,
+    top: 300,
+    left: 80,
+    right: 80,
+  });
+  if (topHook) containerChildren.push(topHook);
+
+  const contentChildren: any[] = [];
+  if (args.eyebrow) {
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 500,
+          fontSize: 22,
+          color: C.sage,
+          letterSpacing: 4,
+          marginBottom: 16,
+        },
+        children: args.eyebrow.toUpperCase(),
+      },
+    });
+  }
+  contentChildren.push({
+    type: "span",
+    props: {
+      style: {
+        fontFamily: "Playfair Display",
+        fontWeight: 700,
+        fontStyle: args.locationItalic ? "italic" : "normal",
+        fontSize: 192,
+        color: C.white,
+        lineHeight: 1.0,
+        textAlign: "center" as const,
+      },
+      children: args.location,
+    },
+  });
+  if (args.subtitle) {
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Playfair Display",
+          fontWeight: 700,
+          fontStyle: "italic",
+          fontSize: 44,
+          color: C.paper,
+          lineHeight: 1.25,
+          marginTop: 10,
+          textAlign: "center" as const,
+        },
+        children: args.subtitle,
+      },
+    });
+  }
+  if (args.layout === "horizontal") {
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: {
+          marginTop: 36,
+          display: "flex",
+          width: "100%",
+        },
+        children: [
+          tripDetailsRow(args, {
+            priceSizes: { eyebrow: 20, struck: 28, price: 42 },
+            seatsDot: 16,
+            seatsCaption: 26,
+            datesSize: 30,
+            rowHeight: 172,
+            width: 920,
+            exclusivityFont: 24,
+          }),
+        ],
+      },
+    });
+  } else {
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: {
+          marginTop: 36,
+          display: "flex",
+        },
+        children: [
+          pricingNode(args, { eyebrow: 22, struck: 32, price: 48 }, "center"),
+        ],
+      },
+    });
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: { marginTop: 30, display: "flex" },
+        children: [seatsStacked(args, 16, 30)],
+      },
+    });
+    if (args.exclusivity) {
+      contentChildren.push(
+        exclusivitySpan(args.exclusivity, 24, "center", 30),
+      );
+    }
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: 36,
+          color: C.white,
+          letterSpacing: 4,
+          marginTop: args.exclusivity ? 14 : 26,
+          textAlign: "center" as const,
+        },
+        children: args.dates.toUpperCase(),
+      },
+    });
+  }
+
+  containerChildren.push({
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        top: 700,
+        left: 80,
+        right: 80,
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: "center",
+      },
+      children: contentChildren,
+    },
+  });
+
+  containerChildren.push({
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        left: 80,
+        right: 80,
+        bottom: 340,
+        display: "flex",
+      },
+      children: [footerBlock(args, 40, 28, "center")],
+    },
+  });
+
+  return {
+    type: "div",
+    props: {
+      style: {
+        width: W,
+        height: H,
+        display: "flex",
+        flexDirection: "column" as const,
+        position: "relative" as const,
+        fontFamily: "Source Sans 3",
+      },
+      children: containerChildren,
+    },
+  };
+}
+
+function buildSquareJsx(args: Args) {
+  const { width: W, height: H } = DIMS.square;
+
+  const containerChildren: any[] = [];
+
+  const contentChildren: any[] = [];
+  if (args.eyebrow) {
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 500,
+          fontSize: 40,
+          color: C.sage,
+          letterSpacing: 7,
+          marginBottom: 25,
+        },
+        children: args.eyebrow.toUpperCase(),
+      },
+    });
+  }
+  contentChildren.push({
+    type: "span",
+    props: {
+      style: {
+        fontFamily: "Playfair Display",
+        fontWeight: 700,
+        fontStyle: args.locationItalic ? "italic" : "normal",
+        fontSize: 280,
+        color: C.white,
+        lineHeight: 1.0,
+      },
+      children: args.location,
+    },
+  });
+  if (args.subtitle) {
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Playfair Display",
+          fontWeight: 700,
+          fontStyle: "italic",
+          fontSize: 75,
+          color: C.paper,
+          lineHeight: 1.2,
+          marginTop: 10,
+        },
+        children: args.subtitle,
+      },
+    });
+  }
+  if (args.layout === "horizontal") {
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: {
+          marginTop: 50,
+          display: "flex",
+          width: "100%",
+        },
+        children: [
+          tripDetailsRow(args, {
+            priceSizes: { eyebrow: 37, struck: 55, price: 80 },
+            seatsDot: 32,
+            seatsCaption: 55,
+            datesSize: 65,
+            rowHeight: 320,
+            width: 2372,
+            exclusivityFont: 45,
+          }),
+        ],
+      },
+    });
+  } else {
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: { marginTop: 45, display: "flex" },
+        children: [pricingNode(args, { eyebrow: 40, struck: 60, price: 90 })],
+      },
+    });
+    contentChildren.push({
+      type: "div",
+      props: {
+        style: { marginTop: 40, display: "flex" },
+        children: [seatsHorizontal(args, 32, 60)],
+      },
+    });
+    if (args.exclusivity) {
+      contentChildren.push(
+        exclusivitySpan(args.exclusivity, 45, "flex-start", 40),
+      );
+    }
+    contentChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: 70,
+          color: C.white,
+          letterSpacing: 10,
+          marginTop: args.exclusivity ? 20 : 30,
+        },
+        children: args.dates.toUpperCase(),
+      },
+    });
+  }
+
+  containerChildren.push({
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        left: 160,
+        right: 160,
+        bottom: 550,
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: "flex-start",
+      },
+      children: contentChildren,
+    },
+  });
+
+  containerChildren.push({
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        left: 160,
+        right: 160,
+        bottom: 200,
+        display: "flex",
+      },
+      children: [footerBlock(args, 75, 55, "flex-start")],
+    },
+  });
+
+  return {
+    type: "div",
+    props: {
+      style: {
+        width: W,
+        height: H,
+        display: "flex",
+        flexDirection: "column" as const,
+        position: "relative" as const,
+        fontFamily: "Source Sans 3",
+      },
+      children: containerChildren,
+    },
+  };
+}
+
+const BUILDERS: Record<Format, (args: Args) => any> = {
+  post: buildPostJsx,
+  story: buildStoryJsx,
+  square: buildSquareJsx,
+};
+
+async function renderOverlay(
+  jsx: any,
+  width: number,
+  height: number,
+  fonts: Awaited<ReturnType<typeof loadFonts>>,
+): Promise<Buffer> {
+  const svg = await satori(jsx, { width, height, fonts });
+  return sharp(Buffer.from(svg), { density: 144 })
+    .resize(width, height, { kernel: "lanczos3" })
+    .png()
+    .toBuffer();
+}
+
+async function renderFormat(
+  args: Args,
+  format: Format,
+  fonts: Awaited<ReturnType<typeof loadFonts>>,
+): Promise<Buffer> {
+  const { width, height } = DIMS[format];
+  const bg = await buildBackground(args.image, width, height, format);
+  const overlay = await renderOverlay(BUILDERS[format](args), width, height, fonts);
+  return sharp(bg)
+    .composite([{ input: overlay, blend: "over" }])
+    .jpeg({ quality: 96, chromaSubsampling: "4:4:4", mozjpeg: true })
+    .toBuffer();
+}
+
+async function main() {
+  const args = parseArgs();
+
+  process.stdout.write("Loading fonts... ");
+  const fonts = await loadFonts();
+  console.log("done");
+
+  const today = new Date().toISOString().slice(0, 10);
+  const dir = path.join(OUTPUT_ROOT, today);
+  await fs.mkdir(dir, { recursive: true });
+
+  for (const format of args.formats) {
+    const { width, height } = DIMS[format];
+    process.stdout.write(`Rendering ${format} (${width}x${height})... `);
+    const buf = await renderFormat(args, format, fonts);
+    const filename = `tour_poster_tmh_${args.name}_${PLATFORM_SUFFIX[format]}.jpg`;
+    const out = path.join(dir, filename);
+    await fs.writeFile(out, buf);
+    console.log(`done\n  ✓ ${out}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a `tour-poster` Claude Code skill (`.claude/skills/tour-poster/SKILL.md`) for generating Instagram-ready tour/workshop posters.
- Adds `scripts/generate-tour-poster.ts` (satori + sharp renderer) and wires it up as `yarn tour-poster`.
- Ignores the local `input/` and `output/` working directories for the skill.

## Test plan
- [x] `yarn tour-poster` runs end-to-end against a sample input image and writes a poster to `output/`.
- [x] SKILL.md instructions are sufficient to invoke the skill from a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)