### PR TITLE
Gallery: show all images; tour-poster: tiers + tagline

### DIFF
--- a/lib/helpers/index.ts
+++ b/lib/helpers/index.ts
@@ -90,15 +90,30 @@ export interface GalleryImage {
  * @param limit
  * @returns
  */
-export async function listImages(limit = 20): Promise<GalleryImage[]> {
+export async function listImages(limit?: number): Promise<GalleryImage[]> {
   const expression = "folder=wildlife";
+  const pageSize = 500;
 
-  const searchQuery = cloudinary.search
-    .expression(expression)
-    .with_field("context")
-    .max_results(limit);
+  const resources: any[] = [];
+  let nextCursor: string | undefined;
 
-  const { resources } = await searchQuery.execute();
+  do {
+    const remaining = limit ? limit - resources.length : pageSize;
+    const batchSize = Math.min(pageSize, remaining);
+
+    let searchQuery = cloudinary.search
+      .expression(expression)
+      .with_field("context")
+      .max_results(batchSize);
+
+    if (nextCursor) {
+      searchQuery = searchQuery.next_cursor(nextCursor);
+    }
+
+    const result = await searchQuery.execute();
+    resources.push(...result.resources);
+    nextCursor = result.next_cursor;
+  } while (nextCursor && (!limit || resources.length < limit));
 
   return resources.map((r) => ({
     id: r.public_id,

--- a/pages/gallery.tsx
+++ b/pages/gallery.tsx
@@ -14,7 +14,7 @@ interface GalleryProps {
 
 export async function getStaticProps() {
   try {
-    const images = await listImages(30);
+    const images = await listImages();
 
     return {
       props: {

--- a/scripts/generate-tour-poster.ts
+++ b/scripts/generate-tour-poster.ts
@@ -48,6 +48,7 @@ type Args = {
   price: string;
   phone: string;
   priceOriginal: string | null;
+  priceTiers: Array<{ label: string; price: string }> | null;
   discountLabel: string;
   priceSuffix: string;
   eyebrow: string | null;
@@ -57,6 +58,7 @@ type Args = {
   locationItalic: boolean;
   instagram: string;
   website: string;
+  footerTagline: string | null;
   name: string;
   formats: Format[];
   layout: "vertical" | "horizontal";
@@ -148,6 +150,7 @@ function parseArgs(): Args {
   const seatsText = flag("seats-text");
   const seatsTotalRaw = flag("seats-total");
   const seatsFilledRaw = flag("seats-filled");
+  const priceTiersRaw = flag("price-tiers");
 
   let seatsTotal = 0;
   let seatsFilled = 0;
@@ -158,10 +161,10 @@ function parseArgs(): Args {
         "Both --seats-text and numeric --seats-* flags supplied; using --seats-text (dots indicator suppressed).",
       );
     }
-  } else {
+  } else if (seatsTotalRaw || seatsFilledRaw) {
     if (!seatsTotalRaw || !seatsFilledRaw) {
       console.error(
-        "Provide either --seats-text \"<label>\" OR both --seats-total + --seats-filled (integers).",
+        "Provide either --seats-text \"<label>\" OR both --seats-total + --seats-filled (integers), or neither.",
       );
       process.exit(1);
     }
@@ -177,6 +180,31 @@ function parseArgs(): Args {
       console.error(
         "--seats-total must be a positive integer; --seats-filled must be 0..seats-total",
       );
+      process.exit(1);
+    }
+  }
+
+  let priceTiers: Array<{ label: string; price: string }> | null = null;
+  if (priceTiersRaw) {
+    priceTiers = priceTiersRaw
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((entry) => {
+        const idx = entry.indexOf(":");
+        if (idx === -1) {
+          console.error(
+            `--price-tiers entries must use "<label>:<price>" format; got "${entry}"`,
+          );
+          process.exit(1);
+        }
+        return {
+          label: entry.slice(0, idx).trim(),
+          price: entry.slice(idx + 1).trim(),
+        };
+      });
+    if (priceTiers.length === 0) {
+      console.error("--price-tiers must contain at least one tier");
       process.exit(1);
     }
   }
@@ -208,9 +236,10 @@ function parseArgs(): Args {
     seatsTotal,
     seatsFilled,
     seatsText,
-    price: required("price"),
+    price: priceTiers ? (flag("price") ?? priceTiers[0].price) : required("price"),
     phone: required("phone"),
     priceOriginal: flag("price-original"),
+    priceTiers,
     discountLabel: flag("discount-label") ?? "EARLY BIRD",
     priceSuffix: flag("price-suffix") ?? "/ PERSON",
     eyebrow: flag("eyebrow"),
@@ -220,6 +249,7 @@ function parseArgs(): Args {
     locationItalic: boolFlag("location-italic"),
     instagram: flag("instagram") ?? "@tarang.hirani",
     website: flag("website") ?? "taranghirani.com",
+    footerTagline: flag("footer-tagline"),
     name: snakeify(flag("name") ?? location),
     formats,
     layout,
@@ -459,23 +489,85 @@ function pricingNode(
       },
     });
   }
-  children.push({
-    type: "span",
-    props: {
-      style: {
-        fontFamily: "Source Sans 3",
-        fontWeight: 700,
-        fontSize: sizes.price,
-        color: C.white,
-        letterSpacing: 4,
-        marginTop: args.priceOriginal ? 4 : 0,
+  if (args.priceTiers) {
+    const tierPriceSize = Math.round(sizes.price * 0.85);
+    const tierLabelSize = tierPriceSize;
+    const labelColWidth = Math.round(tierLabelSize * 3.6);
+    args.priceTiers.forEach((tier, i) => {
+      children.push({
+        type: "div",
+        props: {
+          style: {
+            display: "flex",
+            flexDirection: "row" as const,
+            alignItems: "center",
+            marginTop: i === 0 ? (args.priceOriginal ? 14 : 0) : 10,
+          },
+          children: [
+            {
+              type: "span",
+              props: {
+                style: {
+                  fontFamily: "Source Sans 3",
+                  fontWeight: 700,
+                  fontSize: tierLabelSize,
+                  color: C.sage,
+                  letterSpacing: 4,
+                  width: labelColWidth,
+                },
+                children: tier.label.toUpperCase(),
+              },
+            },
+            {
+              type: "span",
+              props: {
+                style: {
+                  fontFamily: "Source Sans 3",
+                  fontWeight: 700,
+                  fontSize: tierPriceSize,
+                  color: C.white,
+                  letterSpacing: 4,
+                },
+                children: tier.price.toUpperCase(),
+              },
+            },
+            {
+              type: "span",
+              props: {
+                style: {
+                  fontFamily: "Source Sans 3",
+                  fontWeight: 500,
+                  fontSize: Math.round(tierPriceSize * 0.55),
+                  color: C.paper,
+                  letterSpacing: 2,
+                  marginLeft: 10,
+                },
+                children: args.priceSuffix.replace(/^\/\s*/, "/").toLowerCase(),
+              },
+            },
+          ],
+        },
+      });
+    });
+  } else {
+    children.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: sizes.price,
+          color: C.white,
+          letterSpacing: 4,
+          marginTop: args.priceOriginal ? 4 : 0,
+        },
+        children: stackedSuffix
+          ? args.price.toUpperCase()
+          : `${args.price} ${args.priceSuffix}`.toUpperCase(),
       },
-      children: stackedSuffix
-        ? args.price.toUpperCase()
-        : `${args.price} ${args.priceSuffix}`.toUpperCase(),
-    },
-  });
-  if (stackedSuffix && args.priceSuffix) {
+    });
+  }
+  if (stackedSuffix && args.priceSuffix && !args.priceTiers) {
     children.push({
       type: "span",
       props: {
@@ -600,7 +692,104 @@ function footerBlock(
   phoneSize: number,
   handleSize: number,
   align: "flex-start" | "center" = "flex-start",
+  includeFooterTagline: boolean = false,
 ) {
+  const showTagline = includeFooterTagline && !!args.footerTagline;
+
+  const phoneSpan = {
+    type: "span",
+    props: {
+      style: {
+        fontFamily: "Source Sans 3",
+        fontWeight: 700,
+        fontSize: phoneSize,
+        color: C.white,
+        letterSpacing: 2,
+      },
+      children: `CALL ${args.phone}`,
+    },
+  };
+
+  const phoneRow = showTagline
+    ? {
+        type: "div",
+        props: {
+          style: {
+            display: "flex",
+            flexDirection: "row" as const,
+            alignItems: "center",
+            marginTop: 18,
+          },
+          children: [
+            phoneSpan,
+            {
+              type: "span",
+              props: {
+                style: {
+                  fontFamily: "Source Sans 3",
+                  fontWeight: 700,
+                  fontSize: phoneSize,
+                  color: C.sage,
+                  marginLeft: 28,
+                  marginRight: 28,
+                  lineHeight: 1,
+                },
+                children: "•",
+              },
+            },
+            {
+              type: "span",
+              props: {
+                style: {
+                  fontFamily: "Source Sans 3",
+                  fontWeight: 700,
+                  fontSize: phoneSize,
+                  color: C.white,
+                  letterSpacing: 2,
+                },
+                children: args.footerTagline,
+              },
+            },
+          ],
+        },
+      }
+    : {
+        type: "div",
+        props: {
+          style: { display: "flex", marginTop: 18 },
+          children: [phoneSpan],
+        },
+      };
+
+  const children: any[] = [
+    {
+      type: "div",
+      props: {
+        style: {
+          width: "100%",
+          height: 1,
+          backgroundColor: C.sage,
+          opacity: 0.7,
+        },
+      },
+    },
+    phoneRow,
+    {
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 600,
+          fontSize: handleSize,
+          color: C.sage,
+          letterSpacing: 3,
+          marginTop: 6,
+        },
+        children: `${args.instagram}  ·  ${args.website}`,
+      },
+    },
+  ];
+
   return {
     type: "div",
     props: {
@@ -610,47 +799,7 @@ function footerBlock(
         alignItems: align,
         width: "100%",
       },
-      children: [
-        {
-          type: "div",
-          props: {
-            style: {
-              width: "100%",
-              height: 1,
-              backgroundColor: C.sage,
-              opacity: 0.7,
-            },
-          },
-        },
-        {
-          type: "span",
-          props: {
-            style: {
-              fontFamily: "Source Sans 3",
-              fontWeight: 700,
-              fontSize: phoneSize,
-              color: C.white,
-              letterSpacing: 2,
-              marginTop: 18,
-            },
-            children: `CALL ${args.phone}`,
-          },
-        },
-        {
-          type: "span",
-          props: {
-            style: {
-              fontFamily: "Source Sans 3",
-              fontWeight: 600,
-              fontSize: handleSize,
-              color: C.sage,
-              letterSpacing: 3,
-              marginTop: 6,
-            },
-            children: `${args.instagram}  ·  ${args.website}`,
-          },
-        },
-      ],
+      children,
     },
   };
 }
@@ -803,6 +952,19 @@ function tripDetailsRow(
     },
   });
 
+  const showSeats = !!args.seatsText || args.seatsTotal > 0;
+  const rowChildren: any[] = [
+    column([pricingNode(args, opts.priceSizes, "flex-start", true)], "flex-start", 0, 16),
+    divider,
+  ];
+  if (showSeats) {
+    rowChildren.push(
+      column([seatsStacked(args, opts.seatsDot, opts.seatsCaption)], "center"),
+      divider,
+    );
+  }
+  rowChildren.push(column(datesColumnChildren, "flex-start", 16, 0));
+
   return {
     type: "div",
     props: {
@@ -810,15 +972,9 @@ function tripDetailsRow(
         width: opts.width,
         display: "flex",
         flexDirection: "row" as const,
-        alignItems: "center" as const,
+        alignItems: "flex-start" as const,
       },
-      children: [
-        column([pricingNode(args, opts.priceSizes, "flex-start", true)], "flex-start", 0, 16),
-        divider,
-        column([seatsStacked(args, opts.seatsDot, opts.seatsCaption)], "center"),
-        divider,
-        column(datesColumnChildren, "flex-start", 16, 0),
-      ],
+      children: rowChildren,
     },
   };
 }
@@ -1324,7 +1480,7 @@ function buildSquareJsx(args: Args) {
         bottom: 200,
         display: "flex",
       },
-      children: [footerBlock(args, 75, 55, "flex-start")],
+      children: [footerBlock(args, 75, 55, "flex-start", true)],
     },
   });
 

--- a/scripts/panna-workshop-poster.ts
+++ b/scripts/panna-workshop-poster.ts
@@ -1,0 +1,446 @@
+import satori from "satori";
+import sharp from "sharp";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+const WIDTH = 1080;
+const HEIGHT = 1350;
+
+const C = {
+  charcoal: "#080808",
+  paper: "#F5F5F3",
+  smoke: "#525252",
+  sage: "#C4956A",
+  white: "#FFFFFF",
+};
+
+const FONTS_DIR = path.join(process.cwd(), "node_modules");
+
+async function loadFonts() {
+  const [
+    playfairBold,
+    playfairBoldItalic,
+    sourceSansRegular,
+    sourceSansSemiBold,
+    sourceSansBold,
+  ] = await Promise.all([
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/playfair-display/files/playfair-display-latin-700-normal.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/playfair-display/files/playfair-display-latin-700-italic.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/source-sans-3/files/source-sans-3-latin-400-normal.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/source-sans-3/files/source-sans-3-latin-600-normal.woff",
+      ),
+    ),
+    fs.readFile(
+      path.join(
+        FONTS_DIR,
+        "@fontsource/source-sans-3/files/source-sans-3-latin-700-normal.woff",
+      ),
+    ),
+  ]);
+
+  return [
+    {
+      name: "Playfair Display",
+      data: playfairBold.buffer as ArrayBuffer,
+      weight: 700 as const,
+      style: "normal" as const,
+    },
+    {
+      name: "Playfair Display",
+      data: playfairBoldItalic.buffer as ArrayBuffer,
+      weight: 700 as const,
+      style: "italic" as const,
+    },
+    {
+      name: "Source Sans 3",
+      data: sourceSansRegular.buffer as ArrayBuffer,
+      weight: 400 as const,
+      style: "normal" as const,
+    },
+    {
+      name: "Source Sans 3",
+      data: sourceSansSemiBold.buffer as ArrayBuffer,
+      weight: 600 as const,
+      style: "normal" as const,
+    },
+    {
+      name: "Source Sans 3",
+      data: sourceSansBold.buffer as ArrayBuffer,
+      weight: 700 as const,
+      style: "normal" as const,
+    },
+  ];
+}
+
+async function buildBackground(imagePath: string): Promise<Buffer> {
+  const imgBuffer = await fs.readFile(imagePath);
+
+  // Cover-fit the tiger into 1080x1350
+  const cover = await sharp(imgBuffer)
+    .resize(WIDTH, HEIGHT, { fit: "cover", position: "centre" })
+    .png()
+    .toBuffer();
+
+  // Subtle vignette darken to give text breathing room
+  const vignette = Buffer.from(
+    `<svg width="${WIDTH}" height="${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="topShade" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="rgba(8,8,8,0.80)"/>
+          <stop offset="14%" stop-color="rgba(8,8,8,0.45)"/>
+          <stop offset="25%" stop-color="rgba(8,8,8,0.0)"/>
+        </linearGradient>
+        <linearGradient id="bottomShade" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0%" stop-color="rgba(8,8,8,0.92)"/>
+          <stop offset="35%" stop-color="rgba(8,8,8,0.55)"/>
+          <stop offset="55%" stop-color="rgba(8,8,8,0.0)"/>
+        </linearGradient>
+      </defs>
+      <rect width="100%" height="100%" fill="url(#topShade)"/>
+      <rect width="100%" height="100%" fill="url(#bottomShade)"/>
+    </svg>`,
+  );
+
+  return sharp(cover)
+    .composite([{ input: vignette, blend: "over" }])
+    .png()
+    .toBuffer();
+}
+
+async function buildOverlay(
+  fonts: Awaited<ReturnType<typeof loadFonts>>,
+): Promise<Buffer> {
+  // No frame, no badge — text-only overlay
+  const frameSvg = `<svg width="${WIDTH}" height="${HEIGHT}" xmlns="http://www.w3.org/2000/svg"></svg>`;
+
+  const overlay = {
+    type: "div",
+    props: {
+      style: {
+        width: WIDTH,
+        height: HEIGHT,
+        display: "flex",
+        flexDirection: "column" as const,
+        position: "relative" as const,
+        fontFamily: "Source Sans 3",
+      },
+      children: [
+        // ===== Top hook =====
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              top: 80,
+              left: 76,
+              right: 76,
+              display: "flex",
+              flexDirection: "column" as const,
+              alignItems: "center",
+              gap: 14,
+            },
+            children: [
+              {
+                type: "span",
+                props: {
+                  style: {
+                    fontFamily: "Playfair Display",
+                    fontWeight: 700,
+                    fontStyle: "italic",
+                    fontSize: 32,
+                    color: C.white,
+                    letterSpacing: 0.5,
+                    textAlign: "center" as const,
+                  },
+                  children:
+                    "Six safaris. One tiger reserve. Patience does the rest.",
+                },
+              },
+              {
+                type: "div",
+                props: {
+                  style: { width: 48, height: 1, backgroundColor: C.sage },
+                },
+              },
+            ],
+          },
+        },
+
+        // ===== Lower content block =====
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              left: 76,
+              right: 76,
+              bottom: 480,
+              display: "flex",
+              flexDirection: "column" as const,
+              gap: 4,
+            },
+            children: [
+              // Big headline
+              {
+                type: "span",
+                props: {
+                  style: {
+                    fontFamily: "Playfair Display",
+                    fontWeight: 700,
+                    fontSize: 168,
+                    color: C.white,
+                    lineHeight: 1.0,
+                    marginBottom: 6,
+                  },
+                  children: "Panna",
+                },
+              },
+              // Subhead — italic serif
+              {
+                type: "span",
+                props: {
+                  style: {
+                    fontFamily: "Playfair Display",
+                    fontWeight: 700,
+                    fontStyle: "italic",
+                    fontSize: 32,
+                    color: C.paper,
+                    lineHeight: 1.2,
+                    marginBottom: 18,
+                  },
+                  children: "A guided wildlife photography experience",
+                },
+              },
+              // Date + Limited Seats
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    flexDirection: "row" as const,
+                    alignItems: "center",
+                    gap: 18,
+                  },
+                  children: [
+                    {
+                      type: "span",
+                      props: {
+                        style: {
+                          fontFamily: "Source Sans 3",
+                          fontWeight: 700,
+                          fontSize: 28,
+                          color: C.white,
+                          letterSpacing: 4,
+                        },
+                        children: "OCT 21–25, 2026",
+                      },
+                    },
+                    {
+                      type: "span",
+                      props: {
+                        style: {
+                          fontFamily: "Source Sans 3",
+                          fontWeight: 400,
+                          fontSize: 28,
+                          color: C.sage,
+                          letterSpacing: 4,
+                        },
+                        children: "·",
+                      },
+                    },
+                    {
+                      type: "span",
+                      props: {
+                        style: {
+                          fontFamily: "Source Sans 3",
+                          fontWeight: 700,
+                          fontSize: 28,
+                          color: C.sage,
+                          letterSpacing: 4,
+                        },
+                        children: "LIMITED SEATS",
+                      },
+                    },
+                  ],
+                },
+              },
+              // Price + origin line
+              {
+                type: "span",
+                props: {
+                  style: {
+                    fontFamily: "Source Sans 3",
+                    fontWeight: 700,
+                    fontSize: 28,
+                    color: C.white,
+                    letterSpacing: 4,
+                    marginTop: 10,
+                  },
+                  children: "INR 84,999 / PERSON  ·  EX-GWALIOR (GWL)",
+                },
+              },
+            ],
+          },
+        },
+
+        // ===== Footer =====
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              left: 76,
+              right: 76,
+              bottom: 220,
+              display: "flex",
+              flexDirection: "column" as const,
+              gap: 18,
+            },
+            children: [
+              // Divider rule
+              {
+                type: "div",
+                props: {
+                  style: {
+                    width: "100%",
+                    height: 1,
+                    backgroundColor: C.sage,
+                    opacity: 0.7,
+                  },
+                },
+              },
+              // Primary CTA — phone + email
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    flexDirection: "column" as const,
+                    gap: 4,
+                  },
+                  children: [
+                    {
+                      type: "span",
+                      props: {
+                        style: {
+                          fontFamily: "Source Sans 3",
+                          fontWeight: 700,
+                          fontSize: 30,
+                          color: C.white,
+                          letterSpacing: 2,
+                        },
+                        children: "Call +91 70300 47045",
+                      },
+                    },
+                    {
+                      type: "span",
+                      props: {
+                        style: {
+                          fontFamily: "Source Sans 3",
+                          fontWeight: 700,
+                          fontSize: 30,
+                          color: C.white,
+                          letterSpacing: 2,
+                        },
+                        children:
+                          "or email safaris@taranghirani.com to reserve",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+
+  const textSvg = await satori(overlay as any, {
+    width: WIDTH,
+    height: HEIGHT,
+    fonts,
+  });
+
+  const textLayer = await sharp(Buffer.from(textSvg)).png().toBuffer();
+  const frameLayer = await sharp(Buffer.from(frameSvg)).png().toBuffer();
+
+  // Compose frame first (cut around badge area), then text (which paints the badge text)
+  return sharp({
+    create: {
+      width: WIDTH,
+      height: HEIGHT,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .composite([
+      { input: frameLayer, blend: "over" },
+      { input: textLayer, blend: "over" },
+    ])
+    .png()
+    .toBuffer();
+}
+
+async function main() {
+  const imageArgIdx = process.argv.indexOf("--image");
+  if (imageArgIdx === -1) {
+    console.error("Usage: npm run panna-poster -- --image <path>");
+    process.exit(1);
+  }
+  const imagePath = process.argv[imageArgIdx + 1];
+
+  process.stdout.write("Loading fonts... ");
+  const fonts = await loadFonts();
+  console.log("done");
+
+  process.stdout.write("Building background... ");
+  const bg = await buildBackground(imagePath);
+  console.log("done");
+
+  process.stdout.write("Building overlay... ");
+  const overlay = await buildOverlay(fonts);
+  console.log("done");
+
+  const finalBuffer = await sharp(bg)
+    .composite([{ input: overlay, blend: "over" }])
+    .jpeg({ quality: 95 })
+    .toBuffer();
+
+  const today = new Date().toISOString().slice(0, 10);
+  const dir = path.join(
+    process.cwd(),
+    ".claude",
+    "skills",
+    "social-slide",
+    "output",
+    today,
+  );
+  await fs.mkdir(dir, { recursive: true });
+  const outputPath = path.join(dir, "panna-workshop-poster.jpg");
+  await fs.writeFile(outputPath, finalBuffer);
+  console.log(`\n  ✓ ${outputPath}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Gallery page no longer caps at 30 images — `listImages()` paginates through all Cloudinary results via `next_cursor` (500/page) when called without a limit. Home page still requests 20.
- `scripts/generate-tour-poster.ts`: adds `--price-tiers` (multiple labeled price lines) and `--footer-tagline`; makes the seats indicator optional (omit both `--seats-text` and `--seats-*` flags to skip it).
- Adds `scripts/panna-workshop-poster.ts`.

## Test plan
- [ ] `yarn dev` → `/gallery` loads and renders more than 30 photos
- [ ] Home page still shows the expected hero/feature set
- [ ] Re-run an existing tour-poster command (no new flags) to confirm no regression
- [ ] Run a tour-poster command with `--price-tiers "Single:INR 1,00,000;Shared:INR 80,000"` and `--footer-tagline "…"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)