### PR TITLE
seo: per-page OG/Twitter tags and Service JSON-LD for /workshops

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -29,15 +29,27 @@ export default function MyApp({ Component, pageProps }) {
         />
         <title>{meta.title}</title>
         <meta name="description" content={meta.description} />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content={meta.title} />
-        <meta property="og:description" content={meta.description} />
-        <meta property="og:url" content={meta.url} />
-        <meta property="og:image" content={meta.image} />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={meta.title} />
-        <meta name="twitter:description" content={meta.description} />
-        <meta name="twitter:image" content={meta.image} />
+        <meta property="og:type" content="website" key="og:type" />
+        <meta property="og:title" content={meta.title} key="og:title" />
+        <meta
+          property="og:description"
+          content={meta.description}
+          key="og:description"
+        />
+        <meta property="og:url" content={meta.url} key="og:url" />
+        <meta property="og:image" content={meta.image} key="og:image" />
+        <meta
+          name="twitter:card"
+          content="summary_large_image"
+          key="twitter:card"
+        />
+        <meta name="twitter:title" content={meta.title} key="twitter:title" />
+        <meta
+          name="twitter:description"
+          content={meta.description}
+          key="twitter:description"
+        />
+        <meta name="twitter:image" content={meta.image} key="twitter:image" />
         <link rel="canonical" href={canonicalUrl} />
       </Head>
       <Script

--- a/pages/workshops.tsx
+++ b/pages/workshops.tsx
@@ -14,6 +14,37 @@ const IMG = {
   portrait: `${CLOUDINARY_BASE}/8ec3734c-a6c3-4e67-af27-85fe20e6dabe_z8zwst`,
 };
 
+const PAGE_URL = "https://www.taranghirani.com/workshops";
+const PAGE_TITLE = "Wildlife Photography Workshops | Tarang Hirani";
+const PAGE_DESCRIPTION =
+  "Days in the field with a working photographer and expedition leader. India and Africa. Small groups and one to one.";
+const OG_IMAGE =
+  "https://res.cloudinary.com/duiyn8wll/image/upload/w_1200,h_630,c_fill,f_jpg,q_auto/DSC_0959_hshxmc";
+
+const JSON_LD = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Wildlife Photography Workshops",
+  serviceType: "Wildlife photography workshop",
+  provider: {
+    "@type": "Person",
+    name: "Tarang Hirani",
+    url: "https://www.taranghirani.com",
+  },
+  areaServed: [
+    { "@type": "Place", name: "Tadoba, India" },
+    { "@type": "Place", name: "Bandhavgarh, India" },
+    { "@type": "Place", name: "Kanha, India" },
+    { "@type": "Place", name: "Panna, India" },
+    { "@type": "Place", name: "Tanzania" },
+    { "@type": "Place", name: "Zambia" },
+    { "@type": "Place", name: "Botswana" },
+  ],
+  description: PAGE_DESCRIPTION,
+  url: PAGE_URL,
+  image: OG_IMAGE,
+};
+
 const DAY = [
   {
     n: "01",
@@ -46,12 +77,27 @@ export default function WorkshopsPage() {
   return (
     <>
       <Head>
-        <title>Wildlife Photography Workshops | Tarang Hirani</title>
+        <title>{PAGE_TITLE}</title>
+        <meta name="description" content={PAGE_DESCRIPTION} />
+        <meta property="og:title" content={PAGE_TITLE} key="og:title" />
         <meta
-          name="description"
-          content="Days in the field with a working photographer and expedition leader. India and Africa. Small groups and one to one."
+          property="og:description"
+          content={PAGE_DESCRIPTION}
+          key="og:description"
         />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta property="og:url" content={PAGE_URL} key="og:url" />
+        <meta property="og:image" content={OG_IMAGE} key="og:image" />
+        <meta name="twitter:title" content={PAGE_TITLE} key="twitter:title" />
+        <meta
+          name="twitter:description"
+          content={PAGE_DESCRIPTION}
+          key="twitter:description"
+        />
+        <meta name="twitter:image" content={OG_IMAGE} key="twitter:image" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }}
+        />
       </Head>
 
       {/* HERO */}


### PR DESCRIPTION
## Summary
- `/workshops` now ships its own `og:title`, `og:description`, `og:url`, `og:image`, and matching `twitter:*` tags instead of inheriting the homepage defaults from `_app.js`. Social previews on WhatsApp / X / LinkedIn / iMessage will now show the workshops title, description, and the `DSC_0959_hshxmc` field image (sized 1200×630 via Cloudinary transforms) rather than the homepage hero.
- Added a `Service` JSON-LD block to `/workshops` covering provider, `areaServed` (Tadoba, Bandhavgarh, Kanha, Panna, Tanzania, Zambia, Botswana), and description — so Google has a structured signal about what the page offers.
- Added stable `key` props to every OG/Twitter meta tag in `pages/_app.js`. Without keys, Next.js `<Head>` does not dedupe meta tags, so per-page overrides would have shipped alongside the shared defaults. This change is required for the override on `/workshops` to actually win, and unblocks the same pattern for `/gallery`, `/contact`, and `/blog` later.

Addresses items 3 and 4 (workshops-only) of the SEO audit. Other pages and items in the checklist remain for follow-up PRs.

## Test plan
- [x] `yarn build` succeeds.
- [x] Local `yarn start` — `curl /workshops` confirms exactly one of each `og:*` / `twitter:*` tag, all pointing at workshop-specific values; JSON-LD `Service` block is present; canonical resolves to `https://www.taranghirani.com/workshops`.
- [x] Regression — `/` and `/gallery` still render the shared homepage OG defaults.
- [ ] After deploy preview: paste the preview `/workshops` URL into https://www.opengraph.xyz/ and confirm the card shows the workshop title, description, and break image.
- [ ] After deploy preview: run https://search.google.com/test/rich-results on the preview URL and confirm the `Service` schema validates with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)