### PR TITLE
seo: redirect /index to / to fix duplicate canonical

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,4 +7,7 @@ module.exports = {
       },
     ],
   },
+  async redirects() {
+    return [{ source: "/index", destination: "/", permanent: true }];
+  },
 };


### PR DESCRIPTION
## Summary
- Next.js serves the homepage at both `/` and `/index` (HTTP 200, identical content). Google picked `/` as the canonical and flagged `/index` as **"Duplicate, Google chose different canonical than user"** in GSC.
- Add a permanent (308) redirect `/index` → `/` in `next.config.js` so the duplicate URL stops existing.

## Why this happened
`pages/_app.js` builds the canonical from `useRouter().asPath`. When Googlebot renders JS at `/index`, the canonical tag dynamically becomes `https://www.taranghirani.com/index`, conflicting with the sitemap-declared `/`.

## Test plan
- [ ] `yarn dev` and `curl -I http://localhost:3000/index` → expect `308` with `location: /`
- [ ] `curl -I http://localhost:3000/` → expect `200`
- [ ] After deploy: `curl -I https://www.taranghirani.com/index` → expect `308` with `location: /`
- [ ] In GSC: URL Inspection on `/index` → Request Indexing; then "Validate Fix" on the Pages report row

🤖 Generated with [Claude Code](https://claude.com/claude-code)