### PR TITLE
Leads form: type dropdown + source prop (#92) + light /contact theme

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -2,6 +2,8 @@ import React, { FormEvent, useState } from "react";
 
 type Status = "idle" | "loading" | "success" | "error";
 
+type Source = "contact" | "workshops";
+
 type FieldErrors = Partial<
   Record<"name" | "email" | "phone" | "message", string>
 >;
@@ -85,7 +87,7 @@ function validate(fields: {
   return errors;
 }
 
-export default function ContactForm() {
+export default function ContactForm({ source = "contact" }: { source?: Source }) {
   const [status, setStatus] = useState<Status>("idle");
   const [submitError, setSubmitError] = useState<string>("");
   const [countryCode, setCountryCode] = useState("+91");
@@ -120,6 +122,8 @@ export default function ContactForm() {
       message: ((data.get("message") as string) || "").trim(),
     };
 
+    const type = ((data.get("type") as string) || "").trim();
+
     const fieldErrors = validate(fields);
     if (Object.keys(fieldErrors).length > 0) {
       setErrors(fieldErrors);
@@ -135,7 +139,7 @@ export default function ContactForm() {
       const res = await fetch("/api/contact", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...fields, countryCode }),
+        body: JSON.stringify({ ...fields, countryCode, type, source }),
       });
 
       if (res.ok) {
@@ -282,6 +286,40 @@ export default function ContactForm() {
             {errors.phone}
           </p>
         )}
+      </div>
+
+      <div className="mt-8">
+        <label htmlFor="contact-type" className={labelClass}>
+          What&apos;s this about?
+        </label>
+        <div className="relative">
+          <select
+            id="contact-type"
+            name="type"
+            defaultValue=""
+            disabled={status === "loading"}
+            className="appearance-none w-full bg-transparent border-0 border-b border-white/15 px-0 pr-6 py-3 text-base text-white focus:border-sage focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 cursor-pointer"
+          >
+            <option value="" className="bg-charcoal text-white">
+              Select one (optional)
+            </option>
+            <option value="Workshop" className="bg-charcoal text-white">
+              Workshop
+            </option>
+            <option value="Safari" className="bg-charcoal text-white">
+              Safari
+            </option>
+            <option value="Other" className="bg-charcoal text-white">
+              Other
+            </option>
+          </select>
+          <span
+            aria-hidden
+            className="pointer-events-none absolute right-0 bottom-3.5 text-sage text-xs"
+          >
+            ▾
+          </span>
+        </div>
       </div>
 
       <div className="mt-8">

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -4,6 +4,8 @@ type Status = "idle" | "loading" | "success" | "error";
 
 type Source = "contact" | "workshops";
 
+type Theme = "dark" | "light";
+
 type FieldErrors = Partial<
   Record<"name" | "email" | "phone" | "message", string>
 >;
@@ -38,19 +40,6 @@ const COUNTRY_CODES: { code: string; label: string }[] = [
   { code: "+972", label: "Israel" },
   { code: "+90", label: "Turkey" },
 ];
-
-const labelClass =
-  "block text-[11px] font-medium uppercase tracking-[0.2em] text-sage/80 mb-3";
-const baseInputClass =
-  "w-full bg-transparent border-0 border-b px-0 py-3 text-base text-white placeholder:text-white/25 focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50";
-
-function inputClass(hasError: boolean) {
-  return `${baseInputClass} ${
-    hasError
-      ? "border-red-400/70 focus:border-red-400"
-      : "border-white/15 focus:border-sage"
-  }`;
-}
 
 function validate(fields: {
   name: string;
@@ -87,7 +76,40 @@ function validate(fields: {
   return errors;
 }
 
-export default function ContactForm({ source = "contact" }: { source?: Source }) {
+export default function ContactForm({
+  source = "contact",
+  theme = "dark",
+}: {
+  source?: Source;
+  theme?: Theme;
+}) {
+  const isLight = theme === "light";
+
+  // Theme-aware class fragments. Sage stays the accent (hairline, arrow, focus
+  // underline, button border/hover); functional text shifts to charcoal/smoke
+  // on light so it stays legible — sage-on-paper fails contrast.
+  const labelClass = `block text-[11px] font-medium uppercase tracking-[0.2em] mb-3 ${
+    isLight ? "text-smoke" : "text-sage/80"
+  }`;
+  const baseInputClass = `w-full bg-transparent border-0 border-b px-0 py-3 text-base focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 ${
+    isLight
+      ? "text-charcoal placeholder:text-smoke/50"
+      : "text-white placeholder:text-white/25"
+  }`;
+  const normalBorder = isLight ? "border-charcoal/20" : "border-white/15";
+  const errorBorder = isLight
+    ? "border-red-500/70 focus:border-red-500"
+    : "border-red-400/70 focus:border-red-400";
+  const inputClass = (hasError: boolean) =>
+    `${baseInputClass} ${
+      hasError ? errorBorder : `${normalBorder} focus:border-sage`
+    }`;
+  const selectClass = `appearance-none bg-transparent border-0 border-b ${normalBorder} px-0 pr-6 py-3 text-base focus:border-sage focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 cursor-pointer ${
+    isLight ? "text-charcoal" : "text-white"
+  }`;
+  const optionClass = isLight ? "bg-paper text-charcoal" : "bg-charcoal text-white";
+  const errorTextClass = `mt-2 text-xs ${isLight ? "text-red-600" : "text-red-400"}`;
+
   const [status, setStatus] = useState<Status>("idle");
   const [submitError, setSubmitError] = useState<string>("");
   const [countryCode, setCountryCode] = useState("+91");
@@ -164,17 +186,23 @@ export default function ContactForm({ source = "contact" }: { source?: Source })
         <p className="mt-8 text-[11px] font-medium uppercase tracking-[0.2em] text-sage">
           Message Received
         </p>
-        <h3 className="mt-4 font-display text-2xl md:text-3xl font-semibold text-parchment tracking-tight">
+        <h3
+          className={`mt-4 font-display text-2xl md:text-3xl font-semibold tracking-tight ${
+            isLight ? "text-charcoal" : "text-parchment"
+          }`}
+        >
           Thanks — I&apos;ll be in touch.
         </h3>
-        <p className="mt-4 text-sm md:text-base text-white/50">
+        <p
+          className={`mt-4 text-sm md:text-base ${
+            isLight ? "text-smoke" : "text-white/50"
+          }`}
+        >
           I read every message and reply within 48 hours.
         </p>
       </div>
     );
   }
-
-  const errorTextClass = "mt-2 text-xs text-red-400";
 
   return (
     <form onSubmit={handleSubmit} className="w-full" noValidate>
@@ -248,14 +276,10 @@ export default function ContactForm({ source = "contact" }: { source?: Source })
               value={countryCode}
               onChange={(e) => setCountryCode(e.target.value)}
               disabled={status === "loading"}
-              className="appearance-none bg-transparent border-0 border-b border-white/15 px-0 pr-6 py-3 text-base text-white focus:border-sage focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 cursor-pointer"
+              className={selectClass}
             >
               {COUNTRY_CODES.map((c) => (
-                <option
-                  key={c.code}
-                  value={c.code}
-                  className="bg-charcoal text-white"
-                >
+                <option key={c.code} value={c.code} className={optionClass}>
                   {c.label} {c.code}
                 </option>
               ))}
@@ -298,18 +322,18 @@ export default function ContactForm({ source = "contact" }: { source?: Source })
             name="type"
             defaultValue=""
             disabled={status === "loading"}
-            className="appearance-none w-full bg-transparent border-0 border-b border-white/15 px-0 pr-6 py-3 text-base text-white focus:border-sage focus:outline-none focus:ring-0 transition-colors duration-300 disabled:opacity-50 cursor-pointer"
+            className={`${selectClass} w-full`}
           >
-            <option value="" className="bg-charcoal text-white">
+            <option value="" className={optionClass}>
               Select one (optional)
             </option>
-            <option value="Workshop" className="bg-charcoal text-white">
+            <option value="Workshop" className={optionClass}>
               Workshop
             </option>
-            <option value="Safari" className="bg-charcoal text-white">
+            <option value="Safari" className={optionClass}>
               Safari
             </option>
-            <option value="Other" className="bg-charcoal text-white">
+            <option value="Other" className={optionClass}>
               Other
             </option>
           </select>
@@ -352,7 +376,11 @@ export default function ContactForm({ source = "contact" }: { source?: Source })
 
       <div className="mt-10 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
         {status === "error" && (
-          <p className="text-sm text-red-400 sm:mr-auto">
+          <p
+            className={`text-sm sm:mr-auto ${
+              isLight ? "text-red-600" : "text-red-400"
+            }`}
+          >
             {submitError}{" "}
             <a
               href="https://wa.me/917030047045"
@@ -367,7 +395,9 @@ export default function ContactForm({ source = "contact" }: { source?: Source })
         <button
           type="submit"
           disabled={status === "loading"}
-          className="group inline-flex items-center justify-center gap-2 px-7 py-3 border border-sage text-sage text-xs uppercase tracking-[0.15em] font-medium hover:bg-sage hover:text-charcoal transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+          className={`group inline-flex items-center justify-center gap-2 px-7 py-3 border border-sage text-xs uppercase tracking-[0.15em] font-medium hover:bg-sage hover:text-charcoal transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed ${
+            isLight ? "text-charcoal" : "text-sage"
+          }`}
         >
           {status === "loading" ? (
             <span className="inline-block h-3 w-3 border border-sage border-t-transparent rounded-full animate-spin" />

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -15,7 +15,7 @@ export default function ContactPage() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
 
-      <section className="bg-charcoal min-h-screen pt-32 pb-24 md:pt-40 md:pb-32">
+      <section className="bg-paper min-h-screen pt-32 pb-24 md:pt-40 md:pb-32">
         <div className="mx-auto max-w-2xl px-6 md:px-12">
           <FadeIn>
             <div className="text-center">
@@ -23,32 +23,32 @@ export default function ContactPage() {
               <p className="mt-8 text-[11px] font-medium uppercase tracking-[0.2em] text-sage">
                 Get in Touch
               </p>
-              <h1 className="mt-4 font-display text-4xl md:text-5xl lg:text-6xl font-semibold text-parchment tracking-tight">
+              <h1 className="mt-4 font-display text-4xl md:text-5xl lg:text-6xl font-semibold text-charcoal tracking-tight">
                 Let&apos;s talk.
               </h1>
-              <p className="mt-6 text-base md:text-lg leading-relaxed text-white/60">
+              <p className="mt-6 text-base md:text-lg leading-relaxed text-smoke">
                 Looking to learn photography or plan a photography focussed
                 experience? I read every message and reply within 48 hours.
               </p>
             </div>
 
             <div className="mt-14 md:mt-16">
-              <ContactForm />
+              <ContactForm theme="light" />
             </div>
           </FadeIn>
 
           <FadeIn delay={200}>
             <div className="mt-20 md:mt-24 flex items-center justify-center gap-4">
-              <span className="h-px w-12 bg-white/10" />
-              <span className="text-[11px] text-white/30 uppercase tracking-[0.2em]">
+              <span className="h-px w-12 bg-charcoal/10" />
+              <span className="text-[11px] text-smoke uppercase tracking-[0.2em]">
                 Or reach out directly
               </span>
-              <span className="h-px w-12 bg-white/10" />
+              <span className="h-px w-12 bg-charcoal/10" />
             </div>
 
             <div className="mt-10 md:mt-12">
               <ContactLinks
-                theme="dark"
+                theme="light"
                 layout="stack"
                 showLabels
                 includeInstagram


### PR DESCRIPTION
Closes #92, plus a light re-theme of the `/contact` page.

Targets `add-contact-form` (the foundation branch, not yet merged to `main`) so the leads-channel phases stack on it.

## 1. Issue #92 — capture-form refinement (`components/ContactForm.tsx`)
- **`source` prop** — `"contact" | "workshops"`, default `"contact"`; sent in the POST body to `/api/contact`.
- **Optional "What's this about?" dropdown** — `Workshop` / `Safari` / `Other`; submits `type`. Optional → no validation rule.
- Honeypot, per-field validation, and success/error states unchanged.

## 2. Light `/contact` theme (`pages/contact.tsx` + `ContactForm.tsx`)
- Page flips `bg-charcoal` → **`bg-paper`** (`#F5F5F3`, soft off-white), charcoal heading, smoke body/divider text, `ContactLinks` → `theme="light"`.
- `ContactForm` gains a **`theme` prop** (`"dark" | "light"`, default `"dark"` — all other usages unchanged; matters for the Phase 2 `/workshops` embed). Light mode: charcoal field text, grey borders, smoke labels.
- **Accessibility:** sage stays the accent (hairline, dropdown arrow, focus underline, button border/hover), but functional text moves off sage (sage-on-paper ≈ 2:1 contrast) — labels are smoke, submit button uses charcoal text.

## Verification
Drove the running app (Playwright) on `/contact`:
- Dropdown renders between Phone and Message, styled like the underline fields; default empty/optional.
- Empty submit → existing field errors fire, no POST.
- Valid submit with type selected → body carries `type` + `source`; success panel renders.
- Light theme verified legible in both the form and success states.

## Open questions
- **Shade:** currently `paper` (soft off-white). Pure white (`parchment`/`#FFFFFF`) is a one-token swap if preferred.
- Site footer stays dark (global layout footer, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
