### PR TITLE
Leads channel Phase 2: embed contact form on /workshops funnel

### DIFF
--- a/pages/workshops.tsx
+++ b/pages/workshops.tsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import Image from "next/image";
 import FadeIn from "../components/FadeIn";
 import ContactLinks from "../components/ContactLinks";
+import ContactForm from "../components/ContactForm";
 
 const CLOUDINARY_BASE =
   "https://res.cloudinary.com/duiyn8wll/image/upload/f_auto,q_auto";
@@ -412,19 +413,36 @@ export default function WorkshopsPage() {
         id="begin"
         className="scroll-mt-24 border-t border-charcoal/10 bg-paper py-32 md:py-48"
       >
-        <div className="mx-auto max-w-2xl px-6 text-center md:px-12">
+        <div className="mx-auto max-w-2xl px-6 md:px-12">
           <FadeIn>
-            <p className="text-[11px] font-medium uppercase tracking-[0.3em] text-sage">
-              Enquire
-            </p>
-            <h2 className="mt-6 font-display text-3xl font-semibold tracking-tight text-charcoal md:text-5xl lg:text-6xl">
-              One message. The rest is arranged.
-            </h2>
-            <p className="mt-10 text-base leading-[1.85] text-smoke md:text-lg">
-              Tell me where you would like to go. WhatsApp or email is
-              fastest.
-            </p>
-            <div className="mt-16">
+            <div className="text-center">
+              <p className="text-[11px] font-medium uppercase tracking-[0.3em] text-sage">
+                Enquire
+              </p>
+              <h2 className="mt-6 font-display text-3xl font-semibold tracking-tight text-charcoal md:text-5xl lg:text-6xl">
+                One message. The rest is arranged.
+              </h2>
+              <p className="mt-10 text-base leading-[1.85] text-smoke md:text-lg">
+                Tell me where you would like to go and what you hope to make. I
+                read every message and reply within 48 hours.
+              </p>
+            </div>
+
+            <div className="mt-14 md:mt-16">
+              <ContactForm source="workshops" theme="light" />
+            </div>
+          </FadeIn>
+
+          <FadeIn delay={200}>
+            <div className="mt-20 md:mt-24 flex items-center justify-center gap-4">
+              <span className="h-px w-12 bg-charcoal/10" />
+              <span className="text-[11px] text-smoke uppercase tracking-[0.2em]">
+                Or reach out directly
+              </span>
+              <span className="h-px w-12 bg-charcoal/10" />
+            </div>
+
+            <div className="mt-10 md:mt-12">
               <ContactLinks theme="light" layout="row" showLabels />
             </div>
           </FadeIn>


### PR DESCRIPTION
## Goal
Capture the highest-intent surface — the workshops sales page — into the leads channel instead of pushing visitors off-site to WhatsApp/email.

Part of the **Enquiry / Leads Channel** work. Full plan: `docs/contact-form-rollout.md`. Phase 1 (`source` prop + type dropdown) already shipped in #84.

## Changes (`pages/workshops.tsx`)
- Import and embed `<ContactForm source="workshops" theme="light" />` in the closing `#begin` section, wrapped in `FadeIn`.
- Compose to mirror `pages/contact.tsx`: header + form in the first `FadeIn`, then an "Or reach out directly" divider and `ContactLinks` in a second `FadeIn delay={200}` as the secondary path.
- Drop the now-misleading "WhatsApp or email is fastest" line (the form is now primary) and remove `text-center` from the container so form fields align correctly while the header stays centered.

The hero "Enquire" CTA (`href="#begin"`) already targets the section now containing the form, so no CTA change was needed. No new route → no `sitemap.xml` change.

## Acceptance criteria
- [x] Workshops page renders `ContactForm` with `source="workshops"`.
- [x] "Enquire" CTA scrolls to the form (`#begin`, `scroll-mt-24` clears the nav).
- [x] `ContactLinks` remains visible as the secondary option.
- [x] Submissions carry `source = workshops` (already in the POST body; visible in email once Phase 3 / #94 lands).
- [x] No `sitemap.xml` change.

## Verification
`tsc --noEmit` passes clean.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)