### PR TITLE
Leads channel Phase 3: API carries enquiry type + source

### DIFF
--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -12,6 +12,8 @@ const MAX_LEN = {
   phone: 40,
   countryCode: 8,
   message: 5000,
+  type: 40,
+  source: 60,
 };
 
 function escapeHtml(str: string): string {
@@ -52,6 +54,12 @@ export default async function handler(
     message: message.trim(),
   };
 
+  // Optional qualification fields — missing/legacy callers still succeed.
+  const type =
+    typeof req.body?.type === "string" ? req.body.type.trim() : "";
+  const source =
+    typeof req.body?.source === "string" ? req.body.source.trim() : "";
+
   if (
     !trimmed.name ||
     !trimmed.email ||
@@ -67,7 +75,9 @@ export default async function handler(
     trimmed.email.length > MAX_LEN.email ||
     trimmed.phone.length > MAX_LEN.phone ||
     trimmed.countryCode.length > MAX_LEN.countryCode ||
-    trimmed.message.length > MAX_LEN.message
+    trimmed.message.length > MAX_LEN.message ||
+    type.length > MAX_LEN.type ||
+    source.length > MAX_LEN.source
   ) {
     return res.status(400).json({ error: "One of your fields is too long" });
   }
@@ -87,13 +97,17 @@ export default async function handler(
   const resend = new Resend(apiKey);
 
   const fullPhone = `${trimmed.countryCode} ${trimmed.phone}`;
-  const subject = `New enquiry from ${trimmed.name}`;
+  const subject = type
+    ? `${type} enquiry from ${trimmed.name}`
+    : `New enquiry from ${trimmed.name}`;
 
   const text = [
     `New enquiry from ${trimmed.name}`,
     "",
     `Email:  ${trimmed.email}`,
     `Phone:  ${fullPhone}`,
+    ...(type ? [`Type:   ${type}`] : []),
+    `Source: ${source || "—"}`,
     "",
     "Message:",
     trimmed.message,
@@ -114,6 +128,18 @@ export default async function handler(
     <tr>
       <td style="padding:8px 0; color:#525252; font-size:13px; vertical-align:top;">Phone</td>
       <td style="padding:8px 0; font-size:14px;"><a href="tel:${escapeHtml(trimmed.countryCode + trimmed.phone.replace(/\s/g, ""))}" style="color:#080808;">${escapeHtml(fullPhone)}</a></td>
+    </tr>
+    ${
+      type
+        ? `<tr>
+      <td style="padding:8px 0; color:#525252; font-size:13px; vertical-align:top;">Type</td>
+      <td style="padding:8px 0; font-size:14px;">${escapeHtml(type)}</td>
+    </tr>`
+        : ""
+    }
+    <tr>
+      <td style="padding:8px 0; color:#525252; font-size:13px; vertical-align:top;">Source</td>
+      <td style="padding:8px 0; font-size:14px;">${escapeHtml(source || "—")}</td>
     </tr>
   </table>
   <p style="font-size:11px; letter-spacing:0.2em; text-transform:uppercase; color:#525252; margin:0 0 8px;">Message</p>


### PR DESCRIPTION
## Summary

Part of the **Enquiry / Leads Channel** rollout. The contact form already POSTs `type` (Workshop / Safari / Other, optional) and `source` (`contact` / `workshops`) — Phases 1 & 2 — but the serverless handler ignored both. This phase carries that qualification data into the notification email so enquiries can be triaged at a glance.

## Changes — `pages/api/contact.ts` only

- Accept and length-bound `type` / `source` as **optional** fields (new `MAX_LEN` entries); missing/legacy callers still succeed.
- Subject becomes `"{Type} enquiry from {name}"`, falling back to `"New enquiry from {name}"` when `type` is empty.
- Add **Type** (rendered only when set) and **Source** rows to the plain-text and HTML email bodies, escaped via the existing `escapeHtml` helper.
- Recipients, `Reply-To`, and the Resend send path are unchanged. No per-type inbox routing.

## Acceptance criteria

- [x] POST with `type`/`source` succeeds; missing/invalid `type` still works (optional).
- [x] Subject reflects the type prefix; Type + Source appear in text and HTML bodies.
- [x] `Reply-To` still targets the enquirer; both inboxes still receive the mail.
- [x] Over-length `type`/`source` rejected via `MAX_LEN`.

## Verification

- `tsc --noEmit` → clean.
- Local handler smoke tests:
  - With `type` → reaches send step (500 = no local `RESEND_API_KEY`, proving full parse/validation).
  - Without `type` → same, confirms optional behaviour.
  - 100-char `type` → `400 "One of your fields is too long"`.
- Inbox/subject end-to-end check needs a real `RESEND_API_KEY` (lands in Phase 4 / #95).

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)