### PR TITLE
Leads channel Phase 5: auto-acknowledgement email to enquirer

### DIFF
--- a/docs/contact-form-rollout.md
+++ b/docs/contact-form-rollout.md
@@ -23,7 +23,7 @@ This is the lead-capture counterpart to the Kit-driven newsletter funnel — dif
 ## What's already built
 
 - `components/ContactForm.tsx` — name, email, country code + phone, message. Per-field validation, honeypot anti-spam, loading/success/error states.
-- `pages/api/contact.ts` — POST handler that validates input and sends via Resend. Includes plain-text + HTML email bodies.
+- `pages/api/contact.ts` — POST handler that validates input and sends via Resend. Includes plain-text + HTML email bodies. After the notification send succeeds, it also sends a best-effort, branded acknowledgement to the enquirer (24-hour reply promise); an ack failure is logged but never fails the request.
 - `pages/contact.tsx` — form placed above ContactLinks; new copy ("Looking to learn photography or plan a photography focussed experience?").
 - `resend@6.x` added to dependencies.
 
@@ -51,7 +51,7 @@ This is the lead-capture counterpart to the Kit-driven newsletter funnel — dif
 1. Vercel dashboard → Project → Settings → Environment Variables.
 2. Add `RESEND_API_KEY`, mark **Sensitive**, scope to **Production + Preview**.
 3. Skip `CONTACT_FROM_ADDRESS` for now — only set it after §4 is complete.
-4. Redeploy (or trigger a new build) so the new env reaches the running app.
+4. Redeploy (or trigger a new build) so the new env reaches the running app. Env var changes only apply to deployments built **after** the change, and must be scoped to **Production** for `www`. If a production submit returns `{"error":"Server configuration error"}` (HTTP 500), `RESEND_API_KEY` isn't reaching that deployment — check the variable's scope includes Production and that the live deployment was built after the var was added.
 
 **Local:**
 
@@ -64,6 +64,8 @@ RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxx
 ---
 
 ## 3. Smoke Test
+
+> **Ordering note:** on the Resend free tier *before* domain verification (§4), the `onboarding@resend.dev` sender can only deliver to your own Resend signup email. Because the API sends to **both** `safaris@taranghirani.com` and `tarang9211@gmail.com`, a real two-inbox send returns a `403 validation_error` until the domain is verified. Do **§4 first**, then run this two-inbox smoke test.
 
 After the Vercel env var lands and the deploy is live:
 
@@ -90,7 +92,8 @@ After the Vercel env var lands and the deploy is live:
    - `MX` for the return-path (e.g. `send.taranghirani.com` → `feedback-smtp.us-east-1.amazonses.com`)
    - `TXT` for SPF (e.g. `send.taranghirani.com` → `v=spf1 include:amazonses.com ~all`)
    - `TXT` for DKIM (a long key)
-3. Add all three records in your DNS provider (likely Vercel DNS, Cloudflare, or wherever `taranghirani.com` is hosted). Use the **exact** host names Resend shows — usually scoped to a `send.` subdomain.
+3. Add all three records in **Squarespace** (Domains → `taranghirani.com` → DNS → DNS Settings → Custom Records). The nameservers read `ns-cloud-*.googledomains.com` because the domain came via Google Domains, but management is now in Squarespace. Enter the **host as just the subdomain label** (e.g. `send`, `resend._domainkey`) — Squarespace appends the domain. The Resend records are scoped to `send.` / `resend._domainkey`, so they coexist cleanly with the root ImprovMX `MX` + SPF and don't touch inbound alias mail.
+   - **DKIM gotcha:** paste the DKIM key as one unbroken string. Pasting into Squarespace can soft-wrap the value and inject literal spaces into the base64, which can break verification. Verify with `dig +short TXT resend._domainkey.taranghirani.com` and confirm no spaces inside the `p=` value (query the authoritative NS to bypass cache: `dig @ns-cloud-a4.googledomains.com TXT resend._domainkey.taranghirani.com +short`).
 4. Click **Verify** in Resend. Propagation is usually 5–60 minutes; can take up to 24 hours.
 5. Once verified, set the Vercel env var:
    ```
@@ -113,7 +116,6 @@ These are deliberately deferred until there's a real need:
 - **Rate limiting:** Vercel has built-in protections, but if abused, add `upstash/ratelimit` keyed by IP.
 - **Enquiry-type routing:** add a "What's this about?" dropdown (Safari / Workshop / Prints / Collab) and route to different inboxes or use it as the email subject prefix.
 - **CRM sync:** push submissions into Kit as tagged subscribers, or into a Google Sheet via a webhook, so enquiries are searchable.
-- **Auto-acknowledgement email:** send a confirmation email to the enquirer so they know it landed.
 
 ---
 

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -162,6 +162,47 @@ export default async function handler(
       return res.status(500).json({ error: "Failed to send message" });
     }
 
+    // Best-effort acknowledgement to the enquirer. A failure here is logged but
+    // must not fail the request — the notification above already succeeded.
+    try {
+      const ackText = [
+        `Hi ${trimmed.name},`,
+        "",
+        "Thanks for reaching out — your message has landed with me and I'll be in touch within 24 hours.",
+        "",
+        "In the meantime, feel free to browse my work at taranghirani.com or reach me on Instagram @tarang.hirani.",
+        "",
+        "Warm regards,",
+        "Tarang Hirani",
+        "Wildlife Photographer",
+      ].join("\n");
+
+      const ackHtml = `<!doctype html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color:#080808; max-width:560px; margin:0 auto; padding:24px;">
+  <p style="font-size:11px; letter-spacing:0.2em; text-transform:uppercase; color:#C4956A; margin:0 0 16px;">Message Received</p>
+  <p style="font-size:16px; line-height:1.6; margin:0 0 16px;">Hi ${escapeHtml(trimmed.name)},</p>
+  <p style="font-size:16px; line-height:1.6; margin:0 0 16px;">Thanks for reaching out — your message has landed with me and I'll be in touch <strong>within 24 hours</strong>.</p>
+  <p style="font-size:16px; line-height:1.6; margin:0 0 24px;">In the meantime, feel free to browse my work at <a href="https://www.taranghirani.com" style="color:#C4956A;">taranghirani.com</a> or reach me on Instagram <a href="https://instagram.com/tarang.hirani" style="color:#C4956A;">@tarang.hirani</a>.</p>
+  <p style="font-size:16px; line-height:1.6; margin:0;">Warm regards,<br/>Tarang Hirani</p>
+  <p style="font-size:13px; color:#525252; margin:4px 0 0;">Wildlife Photographer</p>
+</body></html>`;
+
+      const { error: ackError } = await resend.emails.send({
+        from: FROM_ADDRESS,
+        to: trimmed.email,
+        replyTo: TO_ADDRESSES[0],
+        subject: "Thanks for reaching out — Tarang Hirani",
+        text: ackText,
+        html: ackHtml,
+      });
+
+      if (ackError) {
+        console.error("Resend ack send error:", ackError);
+      }
+    } catch (ackErr) {
+      console.error("Resend ack request failed:", ackErr);
+    }
+
     return res.status(200).json({ success: true });
   } catch (err) {
     console.error("Resend request failed:", err);


### PR DESCRIPTION
Part of the **Enquiry / Leads Channel** work. Closes #96.

## What this does
After the notification email to the inboxes sends successfully, the contact API now sends a **second** Resend email to the enquirer — a short, on-brand acknowledgement with a **24-hour** reply promise, reusing the existing email styling (`#C4956A` accent, system font). Reply-To points at the primary inbox so a reply to the ack reaches you.

## Safety
- Best-effort: the ack send is wrapped in its own `try/catch`. A failure is logged via `console.error` but **never** fails the request — the notification has already landed.
- No ack is attempted if the primary notification send failed.

## Verification (local, against the verified Resend domain)
- ✅ Valid submit → `200`, ack delivered, no ack error logged.
- ✅ Forced ack failure (temporary broken `to:`) → request still `200`, notification still sent, ack error logged. Reverted before commit.
- ✅ `tsc --noEmit` clean.

## Also included
Phase 4 doc corrections in `docs/contact-form-rollout.md`: DNS is on **Squarespace** (not Vercel), smoke test must follow domain verification, the DKIM-whitespace gotcha, and the `Server configuration error` troubleshooting note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)