### PR TITLE
tour-poster: add --fine-print flag and refine horizontal seats-text layout

### DIFF
--- a/.claude/skills/tour-poster/SKILL.md
+++ b/.claude/skills/tour-poster/SKILL.md
@@ -79,13 +79,14 @@ npm run tour-poster -- [--image <name-or-path>] --location <name> --dates <range
 | `--location-italic` | Render the location in Playfair italic                                                     | off                    |
 | `--instagram`       | Instagram handle (rendered in the footer)                                                  | `@tarang.hirani`       |
 | `--website`         | Website (rendered in the footer)                                                           | `taranghirani.com`     |
+| `--fine-print`      | A single small-print line rendered at the very bottom of the footer, below the handles. White, semibold (Source Sans 600), **not uppercased** — printed verbatim, so include your own separators (e.g. ` · `). Use for terms/notes like flights, booking basis, expense disclosures. | none                   |
 | `--name`            | Override the `<slug>` portion of the output filename                                       | snake_case `--location` |
 | `--formats`         | Comma list of `story`, `post`, `square` to render                                          | `story,post,square`    |
-| `--layout`          | `vertical` (default — every line stacks down the left edge) or `horizontal` (price / seats / dates render as a three-column row separated by sage vertical hairlines; the Playfair location stays a vertical hero above) | `vertical`             |
+| `--layout`          | `vertical` (default — every line stacks down the left edge) or `horizontal` (price / seats / dates render as a column row separated by sage vertical hairlines; the Playfair location stays a vertical hero above). In horizontal layout the **numeric** seat indicator forms its own centered middle column (three columns total); a free-text `--seats-text` label instead renders left-aligned *under the pricing* in the left column, producing a clean two-column split (pricing+label · dates) so the dates column stays wide enough to keep `--exclusivity` on one line. | `vertical`             |
 
 ### Seat caption logic
 
-When `--seats-text` is supplied, the caption is the literal text (uppercased, sage, tracked) and no dots indicator is rendered. The seats column simply reads shorter than its neighbours in horizontal layout — the row's `alignItems: "center"` keeps the row visually balanced.
+When `--seats-text` is supplied, the caption is the literal text (uppercased, sage, tracked) and no dots indicator is rendered. In horizontal layout the label does not get its own column — it renders left-aligned beneath the pricing in the left column, collapsing the row to a two-column split (see `--layout`).
 
 Otherwise (numeric mode), the renderer derives the caption from `--seats-total` + `--seats-filled`:
 

--- a/scripts/generate-tour-poster.ts
+++ b/scripts/generate-tour-poster.ts
@@ -59,6 +59,7 @@ type Args = {
   instagram: string;
   website: string;
   footerTagline: string | null;
+  finePrint: string | null;
   name: string;
   formats: Format[];
   layout: "vertical" | "horizontal";
@@ -250,6 +251,7 @@ function parseArgs(): Args {
     instagram: flag("instagram") ?? "@tarang.hirani",
     website: flag("website") ?? "taranghirani.com",
     footerTagline: flag("footer-tagline"),
+    finePrint: flag("fine-print"),
     name: snakeify(flag("name") ?? location),
     formats,
     layout,
@@ -790,6 +792,23 @@ function footerBlock(
     },
   ];
 
+  if (args.finePrint) {
+    children.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 600,
+          fontSize: Math.round(handleSize * 1.02),
+          color: C.white,
+          letterSpacing: 1,
+          marginTop: 12,
+        },
+        children: args.finePrint,
+      },
+    });
+  }
+
   return {
     type: "div",
     props: {
@@ -952,12 +971,34 @@ function tripDetailsRow(
     },
   });
 
-  const showSeats = !!args.seatsText || args.seatsTotal > 0;
+  // A free-text seats label (e.g. a departure point) groups left-aligned under
+  // the pricing in the same column — a clean 2-column split. The numeric seat
+  // indicator keeps its own centered column (3-column row).
+  const showDots = !args.seatsText && args.seatsTotal > 0;
+  const pricingColumnChildren: any[] = [
+    pricingNode(args, opts.priceSizes, "flex-start", true),
+  ];
+  if (args.seatsText) {
+    pricingColumnChildren.push({
+      type: "span",
+      props: {
+        style: {
+          fontFamily: "Source Sans 3",
+          fontWeight: 700,
+          fontSize: opts.seatsCaption,
+          color: C.sage,
+          letterSpacing: 4,
+          marginTop: Math.round(opts.seatsCaption * 0.7),
+        },
+        children: args.seatsText.toUpperCase(),
+      },
+    });
+  }
   const rowChildren: any[] = [
-    column([pricingNode(args, opts.priceSizes, "flex-start", true)], "flex-start", 0, 16),
+    column(pricingColumnChildren, "flex-start", 0, 16),
     divider,
   ];
-  if (showSeats) {
+  if (showDots) {
     rowChildren.push(
       column([seatsStacked(args, opts.seatsDot, opts.seatsCaption)], "center"),
       divider,


### PR DESCRIPTION
## Summary

Two related improvements to the `tour-poster` skill/generator:

- **New `--fine-print` flag** — renders a single verbatim small-print line at the bottom of the footer (white, Source Sans 600, *not* uppercased), below the handles. For terms/notes like flights, booking basis, or expense disclosures. Separators are printed verbatim, so callers include their own (e.g. ` · `).
- **Horizontal seats-text layout refinement** — in horizontal layout, a free-text `--seats-text` label now renders left-aligned *under the pricing* (a clean 2-column split: pricing+label · dates) instead of claiming its own column. This keeps the dates column wide enough to hold `--exclusivity` on one line. Numeric seat indicators are unchanged — they keep their own centered middle column (3-column row).

## Files

- `scripts/generate-tour-poster.ts` — flag parsing, footer fine-print node, `tripDetailsRow` layout logic.
- `.claude/skills/tour-poster/SKILL.md` — documents the new flag and updated layout behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)