### PR TITLE
Redesign navbar: larger legible links + Contact CTA pill

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,26 +8,35 @@ const navItems = [
   { href: "/workshops", label: "Workshops" },
   { href: "/gallery", label: "Gallery" },
   { href: "/blog", label: "Field Notes" },
-  { href: "/contact", label: "Contact" },
 ];
+
+// Promoted to a CTA pill. Swap to the /workshops item to drive the funnel top instead.
+const ctaItem = { href: "/contact", label: "Contact" };
+
+const isActivePath = (currentPath: string, href: string) =>
+  currentPath === href ||
+  (href !== "/" && currentPath.startsWith(href + "/"));
 
 const getLinkClasses = (
   currentPath: string,
   href: string,
   scrolled: boolean,
 ) => {
-  const isActive =
-    currentPath === href ||
-    (href !== "/" && currentPath.startsWith(href + "/"));
+  const isActive = isActivePath(currentPath, href);
   const baseClasses =
-    "font-display tracking-[0.12em] uppercase transition-colors text-xs";
+    "relative inline-flex items-center py-1 font-display tracking-[0.1em] uppercase text-sm transition-colors after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-sage after:transition-transform after:duration-300 after:ease-out hover:after:scale-x-100";
   const inactiveClasses = scrolled
-    ? "text-smoke/60 hover:text-charcoal"
-    : "text-white/60 hover:text-white";
-  const activeClasses = scrolled ? "text-charcoal" : "text-white";
+    ? "text-smoke hover:text-charcoal"
+    : "text-white/80 hover:text-white";
+  const activeClasses = scrolled
+    ? "text-charcoal font-medium after:scale-x-100"
+    : "text-white font-medium after:scale-x-100";
 
   return `${baseClasses} ${isActive ? activeClasses : inactiveClasses}`;
 };
+
+const ctaClasses =
+  "inline-flex items-center rounded-full bg-sage px-5 py-2 font-display tracking-[0.1em] uppercase text-sm text-charcoal transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md hover:brightness-95";
 
 const Navbar: React.FC = () => {
   const { pathname } = useRouter();
@@ -105,6 +114,13 @@ const Navbar: React.FC = () => {
               {label}
             </Link>
           ))}
+          <Link
+            href={ctaItem.href}
+            className={ctaClasses}
+            aria-current={pathname === ctaItem.href ? "page" : undefined}
+          >
+            {ctaItem.label}
+          </Link>
         </div>
 
         {/* Mobile hamburger */}
@@ -131,22 +147,25 @@ const Navbar: React.FC = () => {
               <Link
                 key={href}
                 href={href}
-                className={`block py-3 font-display tracking-[0.12em] uppercase text-sm transition-colors ${
-                  pathname === href ||
-                  (href !== "/" && pathname.startsWith(href + "/"))
-                    ? "text-charcoal"
-                    : "text-smoke/60 hover:text-charcoal"
+                className={`block py-3 font-display tracking-[0.1em] uppercase text-base transition-colors ${
+                  isActivePath(pathname, href)
+                    ? "text-charcoal font-medium"
+                    : "text-smoke hover:text-charcoal"
                 }`}
-                aria-current={
-                  pathname === href ||
-                  (href !== "/" && pathname.startsWith(href + "/"))
-                    ? "page"
-                    : undefined
-                }
+                aria-current={isActivePath(pathname, href) ? "page" : undefined}
               >
                 {label}
               </Link>
             ))}
+            <Link
+              href={ctaItem.href}
+              className="mt-3 block w-full rounded-full bg-sage px-5 py-3 text-center font-display tracking-[0.1em] uppercase text-base text-charcoal transition-all duration-300 hover:brightness-95"
+              aria-current={
+                pathname === ctaItem.href ? "page" : undefined
+              }
+            >
+              {ctaItem.label}
+            </Link>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Why

The desktop nav items were `text-xs` (12px) uppercase serif at `/60` opacity — tiny, low-contrast (below the WCAG AA bar called out in CLAUDE.md), and with no interactivity cue, so the eye slid past them. A flat row of five equal links also gave the eye no destination.

## What changed (`components/Navbar.tsx`)

**Legibility**
- `text-xs` → `text-sm`; tracking eased `0.12em` → `0.1em`
- Dropped the `/60` opacity → full `text-smoke` / `text-white/80`; active page now `font-medium`

**"Come explore" cue**
- Each link grows a thin **sage underline** from the left on hover, which stays lit under the active page

**CTA hierarchy**
- `Contact` promoted to a solid **sage pill** (charcoal text, ~7.7:1 contrast — passes AA) with a hover lift; mirrored as a full-width pill in the mobile menu (items bumped to `text-base`)
- Pulled into its own `ctaItem` so swapping to Workshops is a one-line change

**Cleanup**
- Extracted a shared `isActivePath` helper

## Verification

- `npx tsc --noEmit` ✅ and `npx next build` ✅ both pass
- ⚠️ Not yet visually verified — `yarn dev` is blocked locally by a Node 20-vs-22 engine mismatch. Reviewer should check the hover underline timing and the sage pill against the hero photo via `npx next dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)