### PR TITLE
Add Meta Pixel tracking with SPA route-change PageViews

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useRouter } from "next/router";
 import Head from "next/head";
 import Script from "next/script";
@@ -5,10 +6,24 @@ import Layout from "../components/Layout";
 import "../styles/globals.css";
 
 const GA_MEASUREMENT_ID = "G-JBM6SPGXWS";
+const META_PIXEL_ID = "1340182068044541";
 
 export default function MyApp({ Component, pageProps }) {
-  const { asPath } = useRouter();
+  const router = useRouter();
+  const { asPath } = router;
   const canonicalUrl = `https://www.taranghirani.com${asPath === "/" ? "" : asPath.split("?")[0]}`;
+
+  // Fire a Meta Pixel PageView on every client-side navigation. The base pixel
+  // code only tracks the initial load, so this covers SPA route changes.
+  useEffect(() => {
+    const handleRouteChange = () => {
+      if (typeof window !== "undefined" && window.fbq) {
+        window.fbq("track", "PageView");
+      }
+    };
+    router.events.on("routeChangeComplete", handleRouteChange);
+    return () => router.events.off("routeChangeComplete", handleRouteChange);
+  }, [router.events]);
 
   const meta = {
     title: "Tarang Hirani | Wildlife Photographer",
@@ -64,6 +79,29 @@ export default function MyApp({ Component, pageProps }) {
           gtag('config', '${GA_MEASUREMENT_ID}');
         `}
       </Script>
+      <Script id="meta-pixel" strategy="afterInteractive">
+        {`
+          !function(f,b,e,v,n,t,s)
+          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+          n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t,s)}(window, document,'script',
+          'https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', '${META_PIXEL_ID}');
+          fbq('track', 'PageView');
+        `}
+      </Script>
+      <noscript>
+        <img
+          height="1"
+          width="1"
+          style={{ display: "none" }}
+          alt=""
+          src={`https://www.facebook.com/tr?id=${META_PIXEL_ID}&ev=PageView&noscript=1`}
+        />
+      </noscript>
       <Component {...pageProps} />
     </Layout>
   );


### PR DESCRIPTION
## What

Adds Meta (Facebook) Pixel tracking to the site so we can measure ad performance, build audiences, and track conversions from Meta/Instagram campaigns.

Pixel ID: `1340182068044541`. All changes are confined to `pages/_app.js`; **GA4 is left entirely untouched**.

## Changes

- **Base pixel + initial PageView** — standard Meta base code injected via `next/script` with `strategy="afterInteractive"`, mirroring the existing GA4 pattern.
- **`<noscript>` fallback** — fires the pixel for visitors with JavaScript disabled.
- **SPA route-change tracking** — a `useEffect` subscribes to `router.events` (`routeChangeComplete`) and re-fires `PageView` on every client-side navigation. The base code only tracks the initial load, so this captures movement across gallery / blog / workshops / contact. Guarded on `window.fbq` so it no-ops before the pixel loads.

## Verification

- `yarn build` passes; sitemap regenerates cleanly.
- Manual check (post-merge / preview): Meta Pixel Helper confirms the pixel loads and `PageView` fires on initial load and on each in-app navigation; Meta Events Manager → Test Events shows events arriving in real time.

## Out of scope

- No consent/cookie banner (parity with current setup).
- No conversion events yet (`Lead` on contact submit, `ViewContent` on workshops) — easy fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)