### PR TITLE
Reduce contact message minimum length from 10 to 4 chars

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -69,8 +69,8 @@ function validate(fields: {
 
   if (!fields.message) {
     errors.message = "Please add a short message.";
-  } else if (fields.message.length < 10) {
-    errors.message = "Tell me a little more — at least a sentence.";
+  } else if (fields.message.length < 4) {
+    errors.message = "Tell me a little more — at least a few characters.";
   }
 
   return errors;


### PR DESCRIPTION
## Summary
- Lowers the client-side minimum length for the contact form message field from 10 to 4 characters
- Updates the validation error copy to match ("at least a few characters" instead of "at least a sentence")

## Notes
The server (`pages/api/contact.ts`) still has no minimum and caps at 5000 chars — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)