### PR TITLE
Panna Oct 2026 workshop page + nav dropdown, listings & prefilled enquiry

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -79,9 +79,17 @@ function validate(fields: {
 export default function ContactForm({
   source = "contact",
   theme = "dark",
+  subject,
+  defaultMessage,
 }: {
   source?: Source;
   theme?: Theme;
+  // When set, the enquiry is pinned to a fixed subject (e.g. a specific
+  // workshop): a hidden field carries it to the API and the freeform
+  // "What's this about?" selector is hidden since the subject supersedes it.
+  subject?: string;
+  // Pre-populates the (still editable) message textarea.
+  defaultMessage?: string;
 }) {
   const isLight = theme === "light";
 
@@ -145,6 +153,7 @@ export default function ContactForm({
     };
 
     const type = ((data.get("type") as string) || "").trim();
+    const subjectField = ((data.get("subject") as string) || "").trim();
 
     const fieldErrors = validate(fields);
     if (Object.keys(fieldErrors).length > 0) {
@@ -161,7 +170,13 @@ export default function ContactForm({
       const res = await fetch("/api/contact", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...fields, countryCode, type, source }),
+        body: JSON.stringify({
+          ...fields,
+          countryCode,
+          type,
+          source,
+          subject: subjectField,
+        }),
       });
 
       if (res.ok) {
@@ -174,7 +189,7 @@ export default function ContactForm({
         if (typeof window !== "undefined" && window.fbq) {
           window.fbq("track", "Lead", {
             content_category: source,
-            content_name: type || "General",
+            content_name: subjectField || type || "General",
           });
         }
       } else {
@@ -215,6 +230,9 @@ export default function ContactForm({
 
   return (
     <form onSubmit={handleSubmit} className="w-full" noValidate>
+      {/* Fixed subject for this enquiry (e.g. a specific workshop) */}
+      {subject && <input type="hidden" name="subject" value={subject} />}
+
       {/* Honeypot — visually hidden but available to bots */}
       <div className="absolute -left-[9999px]" aria-hidden="true">
         <label>
@@ -321,39 +339,41 @@ export default function ContactForm({
         )}
       </div>
 
-      <div className="mt-8">
-        <label htmlFor="contact-type" className={labelClass}>
-          What&apos;s this about?
-        </label>
-        <div className="relative">
-          <select
-            id="contact-type"
-            name="type"
-            defaultValue=""
-            disabled={status === "loading"}
-            className={`${selectClass} w-full`}
-          >
-            <option value="" className={optionClass}>
-              Select one (optional)
-            </option>
-            <option value="Workshop" className={optionClass}>
-              Workshop
-            </option>
-            <option value="Safari" className={optionClass}>
-              Safari
-            </option>
-            <option value="Other" className={optionClass}>
-              Other
-            </option>
-          </select>
-          <span
-            aria-hidden
-            className="pointer-events-none absolute right-0 bottom-3.5 text-sage text-xs"
-          >
-            ▾
-          </span>
+      {!subject && (
+        <div className="mt-8">
+          <label htmlFor="contact-type" className={labelClass}>
+            What&apos;s this about?
+          </label>
+          <div className="relative">
+            <select
+              id="contact-type"
+              name="type"
+              defaultValue=""
+              disabled={status === "loading"}
+              className={`${selectClass} w-full`}
+            >
+              <option value="" className={optionClass}>
+                Select one (optional)
+              </option>
+              <option value="Workshop" className={optionClass}>
+                Workshop
+              </option>
+              <option value="Safari" className={optionClass}>
+                Safari
+              </option>
+              <option value="Other" className={optionClass}>
+                Other
+              </option>
+            </select>
+            <span
+              aria-hidden
+              className="pointer-events-none absolute right-0 bottom-3.5 text-sage text-xs"
+            >
+              ▾
+            </span>
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="mt-8">
         <label htmlFor="contact-message" className={labelClass}>
@@ -364,6 +384,7 @@ export default function ContactForm({
           name="message"
           rows={5}
           disabled={status === "loading"}
+          defaultValue={defaultMessage}
           placeholder="Tell me what you'd like to learn, where you'd like to go, or what you're hoping to make."
           aria-invalid={!!errors.message}
           aria-describedby={

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Menu, X } from "lucide-react";
+import { Menu, X, ChevronDown } from "lucide-react";
+import { workshopsByRegion } from "../lib/workshops";
 
 const navItems = [
   { href: "/", label: "Home" },
@@ -9,6 +10,8 @@ const navItems = [
   { href: "/gallery", label: "Gallery" },
   { href: "/blog", label: "Field Notes" },
 ];
+
+const workshopGroups = workshopsByRegion();
 
 // Promoted to a CTA pill. Swap to the /workshops item to drive the funnel top instead.
 const ctaItem = { href: "/contact", label: "Contact" };
@@ -104,16 +107,71 @@ const Navbar: React.FC = () => {
 
         {/* Desktop links */}
         <div className="hidden md:flex items-center space-x-8">
-          {navItems.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              className={getLinkClasses(pathname, href, scrolled)}
-              aria-current={pathname === href ? "page" : undefined}
-            >
-              {label}
-            </Link>
-          ))}
+          {navItems.map(({ href, label }) =>
+            href === "/workshops" && workshopGroups.length > 0 ? (
+              <div key={href} className="group relative">
+                <Link
+                  href={href}
+                  className={`${getLinkClasses(pathname, href, scrolled)} gap-1`}
+                  aria-haspopup="true"
+                  aria-current={pathname === href ? "page" : undefined}
+                >
+                  {label}
+                  <ChevronDown
+                    size={14}
+                    strokeWidth={2}
+                    aria-hidden
+                    className="transition-transform duration-300 group-hover:rotate-180"
+                  />
+                </Link>
+
+                {/* Dropdown panel — revealed on hover or keyboard focus */}
+                <div className="invisible absolute left-1/2 top-full z-50 w-72 -translate-x-1/2 pt-4 opacity-0 transition-all duration-200 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
+                  <div className="overflow-hidden rounded-lg border border-charcoal/10 bg-white/95 p-2 shadow-lg backdrop-blur-md">
+                    <Link
+                      href="/workshops"
+                      className="block rounded px-3 py-2 font-display text-sm uppercase tracking-[0.1em] text-charcoal transition-colors hover:bg-paper hover:text-sage"
+                    >
+                      All workshops
+                    </Link>
+                    {workshopGroups.map((group) => (
+                      <div key={group.region} className="mt-1">
+                        <p className="px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-[0.2em] text-sage">
+                          {group.region}
+                        </p>
+                        {group.items.map((w) => (
+                          <Link
+                            key={w.slug}
+                            href={w.href}
+                            className="block rounded px-3 py-2 transition-colors hover:bg-paper"
+                            aria-current={
+                              pathname === w.href ? "page" : undefined
+                            }
+                          >
+                            <span className="block font-display text-sm text-charcoal">
+                              {w.location}
+                            </span>
+                            <span className="mt-0.5 block text-xs text-smoke">
+                              {w.dateLabel}
+                            </span>
+                          </Link>
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <Link
+                key={href}
+                href={href}
+                className={getLinkClasses(pathname, href, scrolled)}
+                aria-current={pathname === href ? "page" : undefined}
+              >
+                {label}
+              </Link>
+            ),
+          )}
           <Link
             href={ctaItem.href}
             className={ctaClasses}
@@ -144,18 +202,41 @@ const Navbar: React.FC = () => {
         <div className="md:hidden border-t border-black/5 bg-white/90 backdrop-blur-md">
           <div className="max-w-7xl mx-auto px-6 py-4 flex flex-col gap-1">
             {navItems.map(({ href, label }) => (
-              <Link
-                key={href}
-                href={href}
-                className={`block py-3 font-display tracking-[0.1em] uppercase text-base transition-colors ${
-                  isActivePath(pathname, href)
-                    ? "text-charcoal font-medium"
-                    : "text-smoke hover:text-charcoal"
-                }`}
-                aria-current={isActivePath(pathname, href) ? "page" : undefined}
-              >
-                {label}
-              </Link>
+              <React.Fragment key={href}>
+                <Link
+                  href={href}
+                  className={`block py-3 font-display tracking-[0.1em] uppercase text-base transition-colors ${
+                    isActivePath(pathname, href)
+                      ? "text-charcoal font-medium"
+                      : "text-smoke hover:text-charcoal"
+                  }`}
+                  aria-current={
+                    isActivePath(pathname, href) ? "page" : undefined
+                  }
+                >
+                  {label}
+                </Link>
+                {href === "/workshops" &&
+                  workshopGroups.flatMap((group) =>
+                    group.items.map((w) => (
+                      <Link
+                        key={w.slug}
+                        href={w.href}
+                        className={`block border-l border-charcoal/10 py-2 pl-4 transition-colors ${
+                          pathname === w.href
+                            ? "text-charcoal"
+                            : "text-smoke hover:text-charcoal"
+                        }`}
+                        aria-current={pathname === w.href ? "page" : undefined}
+                      >
+                        <span className="block text-sm">{w.location}</span>
+                        <span className="block text-xs text-smoke/70">
+                          {w.dateLabel}
+                        </span>
+                      </Link>
+                    )),
+                  )}
+              </React.Fragment>
             ))}
             <Link
               href={ctaItem.href}

--- a/components/UpcomingWorkshops.tsx
+++ b/components/UpcomingWorkshops.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import Link from "next/link";
+import Image from "next/image";
+import FadeIn from "./FadeIn";
+import { UPCOMING_WORKSHOPS } from "../lib/workshops";
+
+type Theme = "dark" | "light";
+
+export default function UpcomingWorkshops({
+  theme = "light",
+  showViewAll = false,
+  concise = false,
+}: {
+  theme?: Theme;
+  // Show a link through to the full /workshops page (used on the home page).
+  showViewAll?: boolean;
+  // Lead with dates + availability only, no pricing (used on the home page).
+  concise?: boolean;
+}) {
+  const isDark = theme === "dark";
+
+  const cardBorder = isDark
+    ? "border-white/10 hover:border-sage"
+    : "border-charcoal/10 hover:border-sage";
+  const titleColor = isDark ? "text-white" : "text-charcoal";
+  const summaryColor = isDark ? "text-white/60" : "text-smoke";
+  const ctaColor = isDark
+    ? "border-white/30 text-white group-hover:border-sage group-hover:text-sage"
+    : "border-charcoal/30 text-charcoal group-hover:border-sage group-hover:text-sage";
+
+  return (
+    <section
+      id="workshops"
+      className={`scroll-mt-16 ${isDark ? "bg-charcoal" : "bg-paper"} py-24 md:py-32`}
+    >
+      <div className="mx-auto max-w-5xl px-6 md:px-12 lg:px-20">
+        <FadeIn>
+          <div className="mb-14 text-center md:mb-20">
+            <p className="text-[11px] font-medium uppercase tracking-[0.3em] text-sage">
+              Upcoming workshops
+            </p>
+            <h2
+              className={`mt-6 font-display text-3xl font-semibold tracking-tight md:text-4xl lg:text-5xl ${titleColor}`}
+            >
+              Join a fixed-date trip.
+            </h2>
+          </div>
+        </FadeIn>
+
+        <div className="space-y-10 md:space-y-12">
+          {UPCOMING_WORKSHOPS.map((w, i) => (
+            <FadeIn key={w.slug} delay={i * 80}>
+              <Link
+                href={w.href}
+                className={`group block overflow-hidden border transition-colors duration-300 md:grid md:grid-cols-2 ${cardBorder}`}
+              >
+                <div className="relative aspect-[3/2] w-full overflow-hidden md:aspect-auto md:h-full md:min-h-[20rem]">
+                  <Image
+                    src={w.image}
+                    alt={w.imageAlt}
+                    fill
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    className="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.03]"
+                  />
+                </div>
+                <div className="p-8 md:p-12 lg:p-14">
+                  {!concise && (
+                    <p className="text-[11px] font-medium uppercase tracking-[0.25em] text-sage">
+                      {w.location}
+                    </p>
+                  )}
+                  <h3
+                    className={`font-display text-2xl font-semibold tracking-tight md:text-3xl ${
+                      concise ? "" : "mt-5"
+                    } ${titleColor}`}
+                  >
+                    {concise ? w.location : w.title}
+                  </h3>
+                  <p
+                    className={`mt-4 text-base leading-[1.75] md:text-lg ${summaryColor}`}
+                  >
+                    {w.dateLabel} · {concise ? w.shortSummary : w.summary}
+                  </p>
+                  <span
+                    className={`mt-8 inline-flex items-center gap-3 border-b pb-1 text-[11px] font-medium uppercase tracking-[0.25em] transition-colors duration-300 ${ctaColor}`}
+                  >
+                    View workshop
+                    <span
+                      aria-hidden
+                      className="inline-block transition-transform duration-300 group-hover:translate-x-1"
+                    >
+                      &rarr;
+                    </span>
+                  </span>
+                </div>
+              </Link>
+            </FadeIn>
+          ))}
+        </div>
+
+        {showViewAll && (
+          <FadeIn delay={120}>
+            <div className="mt-14 text-center md:mt-16">
+              <Link
+                href="/workshops"
+                className={`group inline-flex items-center gap-3 text-[11px] font-medium uppercase tracking-[0.25em] transition-colors duration-300 ${
+                  isDark
+                    ? "text-white/70 hover:text-sage"
+                    : "text-smoke hover:text-sage"
+                }`}
+              >
+                All workshops &amp; how they run
+                <span
+                  aria-hidden
+                  className="inline-block transition-transform duration-300 group-hover:translate-x-1"
+                >
+                  &rarr;
+                </span>
+              </Link>
+            </div>
+          </FadeIn>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/lib/workshops.ts
+++ b/lib/workshops.ts
@@ -1,0 +1,48 @@
+// Single source of truth for fixed-date workshops, surfaced both on the home
+// page and the /workshops page so the two never drift apart.
+
+const CLOUDINARY_BASE =
+  "https://res.cloudinary.com/duiyn8wll/image/upload/f_auto,q_auto";
+
+export const REGION_ORDER = ["India", "Africa"] as const;
+export type Region = (typeof REGION_ORDER)[number];
+
+export interface Workshop {
+  slug: string;
+  href: string;
+  title: string;
+  region: Region;
+  location: string;
+  dateLabel: string;
+  summary: string;
+  // Price-free one-liner used where we don't want to lead with cost (home page).
+  shortSummary: string;
+  image: string;
+  imageAlt: string;
+}
+
+export const UPCOMING_WORKSHOPS: Workshop[] = [
+  {
+    slug: "panna-october-2026",
+    href: "/workshops/panna-october-2026",
+    title: "Wildlife Photography Workshop — Panna",
+    region: "India",
+    location: "Panna, Madhya Pradesh",
+    dateLabel: "Oct 21–25, 2026",
+    summary:
+      "4 nights / 5 days · 6 safaris · ₹84,999 per person (twin sharing). Limited seats, first come, first served.",
+    shortSummary: "Limited seats, first come, first served.",
+    image: `${CLOUDINARY_BASE}/_Z9_20250508_TMH_8461_wm_vwr6rk`,
+    imageAlt:
+      "A tiger cooling in a forest pool at the water's edge, framed by dense central-India woodland in golden light",
+  },
+];
+
+// Upcoming workshops grouped by region, in display order, skipping empty
+// regions. Drives the Workshops nav dropdown.
+export function workshopsByRegion(): { region: Region; items: Workshop[] }[] {
+  return REGION_ORDER.map((region) => ({
+    region,
+    items: UPCOMING_WORKSHOPS.filter((w) => w.region === region),
+  })).filter((group) => group.items.length > 0);
+}

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -14,6 +14,7 @@ const MAX_LEN = {
   message: 5000,
   type: 40,
   source: 60,
+  subject: 160,
 };
 
 function escapeHtml(str: string): string {
@@ -59,6 +60,10 @@ export default async function handler(
     typeof req.body?.type === "string" ? req.body.type.trim() : "";
   const source =
     typeof req.body?.source === "string" ? req.body.source.trim() : "";
+  // Fixed enquiry subject (e.g. a specific workshop). When present it both
+  // becomes the email subject line and is recorded in the notification body.
+  const subjectField =
+    typeof req.body?.subject === "string" ? req.body.subject.trim() : "";
 
   if (
     !trimmed.name ||
@@ -77,7 +82,8 @@ export default async function handler(
     trimmed.countryCode.length > MAX_LEN.countryCode ||
     trimmed.message.length > MAX_LEN.message ||
     type.length > MAX_LEN.type ||
-    source.length > MAX_LEN.source
+    source.length > MAX_LEN.source ||
+    subjectField.length > MAX_LEN.subject
   ) {
     return res.status(400).json({ error: "One of your fields is too long" });
   }
@@ -97,13 +103,16 @@ export default async function handler(
   const resend = new Resend(apiKey);
 
   const fullPhone = `${trimmed.countryCode} ${trimmed.phone}`;
-  const subject = type
-    ? `${type} enquiry from ${trimmed.name}`
-    : `New enquiry from ${trimmed.name}`;
+  const subject = subjectField
+    ? subjectField
+    : type
+      ? `${type} enquiry from ${trimmed.name}`
+      : `New enquiry from ${trimmed.name}`;
 
   const text = [
     `New enquiry from ${trimmed.name}`,
     "",
+    ...(subjectField ? [`Re:     ${subjectField}`] : []),
     `Email:  ${trimmed.email}`,
     `Phone:  ${fullPhone}`,
     ...(type ? [`Type:   ${type}`] : []),
@@ -121,6 +130,14 @@ export default async function handler(
   <p style="font-size:11px; letter-spacing:0.2em; text-transform:uppercase; color:#C4956A; margin:0 0 16px;">New Enquiry</p>
   <h1 style="font-size:22px; font-weight:600; margin:0 0 24px;">${escapeHtml(trimmed.name)}</h1>
   <table style="width:100%; border-collapse:collapse; margin-bottom:24px;">
+    ${
+      subjectField
+        ? `<tr>
+      <td style="padding:8px 0; color:#525252; font-size:13px; width:80px; vertical-align:top;">Re</td>
+      <td style="padding:8px 0; font-size:14px; font-weight:600;">${escapeHtml(subjectField)}</td>
+    </tr>`
+        : ""
+    }
     <tr>
       <td style="padding:8px 0; color:#525252; font-size:13px; width:80px; vertical-align:top;">Email</td>
       <td style="padding:8px 0; font-size:14px;"><a href="mailto:${escapeHtml(trimmed.email)}" style="color:#080808;">${escapeHtml(trimmed.email)}</a></td>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import Hero from "../components/Hero";
 import ImageCarousel from "../components/ImageCarousel";
 import SafariOffering from "../components/SafariOffering";
+import UpcomingWorkshops from "../components/UpcomingWorkshops";
 import EmailSignup from "../components/EmailSignup";
 import AboutMe from "../components/AboutMe";
 import Head from "next/head";
@@ -40,6 +41,7 @@ export default function Home({
         alt={heroDesktop.alt}
       />
       <SafariOffering />
+      <UpcomingWorkshops theme="dark" showViewAll concise />
       <EmailSignup variant="section" />
       <ImageCarousel images={carouselImages} />
       <AboutMe />

--- a/pages/workshops.tsx
+++ b/pages/workshops.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import FadeIn from "../components/FadeIn";
 import ContactLinks from "../components/ContactLinks";
 import ContactForm from "../components/ContactForm";
+import UpcomingWorkshops from "../components/UpcomingWorkshops";
 
 const CLOUDINARY_BASE =
   "https://res.cloudinary.com/duiyn8wll/image/upload/f_auto,q_auto";
@@ -407,6 +408,9 @@ export default function WorkshopsPage() {
           </FadeIn>
         </div>
       </section>
+
+      {/* UPCOMING WORKSHOPS */}
+      <UpcomingWorkshops theme="light" />
 
       {/* BEGIN */}
       <section

--- a/pages/workshops/panna-october-2026.tsx
+++ b/pages/workshops/panna-october-2026.tsx
@@ -1,0 +1,565 @@
+import Head from "next/head";
+import Image from "next/image";
+import { Phone, MessageCircle, Mail, Instagram } from "lucide-react";
+import FadeIn from "../../components/FadeIn";
+import ContactForm from "../../components/ContactForm";
+import {
+  PHONE_NUMBER_DISPLAY,
+  PHONE_TEL,
+  EMAIL,
+  EMAIL_MAILTO,
+  INSTAGRAM_URL,
+} from "../../lib/constants";
+
+const CLOUDINARY_BASE =
+  "https://res.cloudinary.com/duiyn8wll/image/upload/f_auto,q_auto";
+
+const IMG = {
+  // Single honest central-India cover frame — not represented as Panna.
+  hero: `${CLOUDINARY_BASE}/_Z9_20250508_TMH_8461_wm_vwr6rk`,
+};
+
+const PAGE_URL = "https://www.taranghirani.com/workshops/panna-october-2026";
+const PAGE_TITLE = "Wildlife Photography Workshop — Panna, MP | Tarang Hirani";
+const PAGE_DESCRIPTION =
+  "A 5-day wildlife photography workshop in Panna, Madhya Pradesh — 6 safaris, in-field guidance, and evening post-processing. Oct 21–25, 2026. Limited seats, first come, first served.";
+const OG_IMAGE =
+  "https://res.cloudinary.com/duiyn8wll/image/upload/w_1200,h_630,c_fill,f_jpg,q_auto/_Z9_20260212_100758_TMH_website_s3qioq";
+
+// Carries through to the enquiry notification so it's clearly a Panna lead.
+const ENQUIRY_SUBJECT =
+  "Panna Wildlife Photography Workshop — 21–25 Oct 2026";
+const ENQUIRY_MESSAGE =
+  "Hi Tarang, I'd like to enquire about the Panna wildlife photography workshop (21–25 Oct 2026). Please share availability and next steps.";
+const WHATSAPP_HREF =
+  "https://wa.me/917030047045?text=" +
+  encodeURIComponent("I'm interested in the Panna workshop");
+
+const JSON_LD = {
+  "@context": "https://schema.org",
+  "@type": "Event",
+  name: "Wildlife Photography Workshop — Panna",
+  description: PAGE_DESCRIPTION,
+  startDate: "2026-10-21",
+  endDate: "2026-10-25",
+  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+  eventStatus: "https://schema.org/EventScheduled",
+  image: OG_IMAGE,
+  url: PAGE_URL,
+  location: {
+    "@type": "Place",
+    name: "Panna Tiger Reserve",
+    address: {
+      "@type": "PostalAddress",
+      addressRegion: "Madhya Pradesh",
+      addressCountry: "IN",
+    },
+  },
+  organizer: {
+    "@type": "Person",
+    name: "Tarang Hirani",
+    url: "https://www.taranghirani.com",
+  },
+  offers: {
+    "@type": "Offer",
+    price: "84999",
+    priceCurrency: "INR",
+    availability: "https://schema.org/LimitedAvailability",
+    url: PAGE_URL,
+  },
+};
+
+const ITINERARY: {
+  date: string;
+  title: string;
+  items: { time: string; text: string }[];
+}[] = [
+  {
+    date: "Oct 21",
+    title: "Arrival",
+    items: [
+      {
+        time: "12:15 pm",
+        text: "Arrive at Khajuraho Airport (HJR), transfer to Naaharbagh",
+      },
+      {
+        time: "5:00 pm",
+        text: "Walkaround at Naaharbagh: an introduction to Panna and its history, then camera setup",
+      },
+      { time: "8:00 pm", text: "Briefing & dinner" },
+      { time: "9:00 pm", text: "Lights out" },
+    ],
+  },
+  {
+    date: "Oct 22–24",
+    title: "Workshop",
+    items: [
+      { time: "4:30 am", text: "Wake up, morning coffee/tea" },
+      { time: "5:00 am", text: "Morning safari, with breakfast in the bush" },
+      { time: "11:30 am", text: "Return to Naaharbagh for lunch" },
+      { time: "3:00 pm", text: "Evening safari" },
+      { time: "7:00 pm", text: "Return and freshen up" },
+      { time: "8:00 pm", text: "Photography & post-processing session" },
+      { time: "9:00 pm", text: "Dinner & lights out" },
+    ],
+  },
+  {
+    date: "Oct 25",
+    title: "Checkout & departure",
+    items: [
+      { time: "8:00 am", text: "Breakfast at Naaharbagh" },
+      {
+        time: "12:00 pm",
+        text: "Transfer to Khajuraho Airport (HJR). Trip concludes.",
+      },
+    ],
+  },
+];
+
+const INCLUDED = [
+  "Accommodation at Naaharbagh",
+  "Airport transfers",
+  "All meals (3 per day)",
+  "All safaris",
+  "On-field photography guidance",
+  "Post-processing sessions",
+];
+
+const NOT_INCLUDED = [
+  "Air fare",
+  "Camera fees (paid at the park gate)",
+  "Beverages, alcoholic and non-alcoholic",
+  "Personal expenses such as laundry",
+  "Anything not listed under inclusions",
+];
+
+const GOOD_TO_KNOW = [
+  "Limited seats, offered on a first-come, first-served basis",
+  "Rooms on a twin-sharing basis (single room available at extra cost)",
+  "Maximum 2 guests per jeep (driver and guide excluded)",
+  "Safari permit fees are subject to revision; any changes will be communicated promptly",
+];
+
+const FACTS = [
+  { label: "Dates", value: "Oct 21–25, 2026" },
+  { label: "Length", value: "4 nights / 5 days" },
+  { label: "Safaris", value: "6 across the trip" },
+  { label: "Base", value: "Naaharbagh, Panna" },
+  { label: "Nearest airport", value: "Khajuraho (HJR)" },
+  { label: "Per jeep", value: "Max 2 guests" },
+];
+
+// Compact, consistent heading + label styles for the dense brochure body.
+const SUBHEAD =
+  "font-display text-xl font-semibold tracking-tight text-charcoal md:text-2xl";
+const MINI_LABEL =
+  "text-[11px] font-medium uppercase tracking-[0.25em] text-sage";
+const BODY_COPY = "text-base leading-[1.8] text-smoke";
+
+function ClaimButton({ className = "" }: { className?: string }) {
+  return (
+    <a
+      href="#enquire"
+      className={`group inline-flex items-center justify-center gap-3 border border-sage bg-sage px-8 py-4 text-[11px] font-medium uppercase tracking-[0.2em] text-charcoal transition-all duration-300 hover:bg-transparent hover:text-sage ${className}`}
+    >
+      Claim your spot
+      <span
+        aria-hidden
+        className="inline-block transition-transform duration-300 group-hover:translate-x-1"
+      >
+        &rarr;
+      </span>
+    </a>
+  );
+}
+
+export default function PannaWorkshopPage() {
+  return (
+    <>
+      <Head>
+        <title>{PAGE_TITLE}</title>
+        <meta name="description" content={PAGE_DESCRIPTION} />
+        <meta property="og:title" content={PAGE_TITLE} key="og:title" />
+        <meta
+          property="og:description"
+          content={PAGE_DESCRIPTION}
+          key="og:description"
+        />
+        <meta property="og:url" content={PAGE_URL} key="og:url" />
+        <meta property="og:image" content={OG_IMAGE} key="og:image" />
+        <meta name="twitter:title" content={PAGE_TITLE} key="twitter:title" />
+        <meta
+          name="twitter:description"
+          content={PAGE_DESCRIPTION}
+          key="twitter:description"
+        />
+        <meta name="twitter:image" content={OG_IMAGE} key="twitter:image" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }}
+        />
+      </Head>
+
+      {/* HERO */}
+      <section className="relative">
+        <div className="relative min-h-[56vh] w-full overflow-hidden md:h-[68vh] md:min-h-0">
+          <Image
+            priority
+            src={IMG.hero}
+            alt="A tiger cooling in a forest pool at the water's edge, framed by dense central-India woodland in golden light"
+            fill
+            sizes="100vw"
+            className="animate-slow-zoom object-cover object-[62%_bottom] md:object-center"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-charcoal/85 via-charcoal/35 to-charcoal/10" />
+
+          <div className="absolute inset-0 flex items-end">
+            <div className="w-full px-6 pb-12 md:px-12 md:pb-16 lg:px-20">
+              <div className="max-w-3xl">
+                <p className="mb-4 text-[11px] font-medium uppercase tracking-[0.3em] text-sage">
+                  A field workshop
+                </p>
+                <h1 className="font-display text-4xl font-semibold leading-[1.05] tracking-tight text-white md:text-5xl lg:text-6xl">
+                  Wildlife Photography Workshop — Panna, MP
+                </h1>
+                <p className="mt-5 max-w-2xl text-base leading-[1.7] text-white/85 md:text-lg">
+                  Oct 21–25, 2026 · 4 nights / 5 days · 6 safaris · Limited
+                  seats · ₹84,999 per person (twin sharing)
+                </p>
+                <ClaimButton className="mt-8" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* BODY — content + sticky essentials card */}
+      <section className="bg-paper py-14 md:py-20">
+        <div className="mx-auto max-w-6xl px-6 md:px-12 lg:px-16">
+          <div className="grid gap-x-12 gap-y-10 md:grid-cols-[1fr_19rem] lg:grid-cols-[1fr_21rem] lg:gap-x-16">
+            {/* MAIN CONTENT */}
+            <div className="order-2 md:order-1">
+              <FadeIn>
+                <div className="space-y-12 md:space-y-14">
+                  {/* Intro */}
+                  <div className={`space-y-4 ${BODY_COPY} md:text-lg`}>
+                    <p>
+                      Five days in one of central India&apos;s quietest tiger
+                      reserves, built entirely around making photographs.
+                      Mornings and evenings in the field, breakfast in the
+                      bush, and unhurried evening sessions where we go through
+                      the day&apos;s frames together. Kept deliberately small,
+                      so the guidance is personal and the jeeps never crowded.
+                    </p>
+                    <p>
+                      This is a workshop, not a sightseeing tour. The aim is to
+                      send you home with images you&apos;re proud of, and with
+                      the habits that made them: reading light, anticipating
+                      behaviour, choosing your position before the moment
+                      arrives.
+                    </p>
+                  </div>
+
+                  {/* Why Panna */}
+                  <div className="border-t border-charcoal/10 pt-12">
+                    <h2 className={SUBHEAD}>Why Panna</h2>
+                    <div className={`mt-4 space-y-4 ${BODY_COPY}`}>
+                      <p>
+                        Panna Tiger Reserve sits in Madhya Pradesh, a short
+                        drive from the temple town of Khajuraho. It&apos;s one
+                        of Indian conservation&apos;s great comeback stories —
+                        tigers were lost here around 2009 and carefully
+                        reintroduced, and the reserve has since recovered into a
+                        thriving habitat. The Ken river runs through it, cutting
+                        gorges and plateaus that give the landscape a character
+                        quite different from the more famous reserves. Beyond
+                        tigers, Panna is rich in leopards, sloth bears,
+                        crocodiles along the Ken, and some of central
+                        India&apos;s best raptor and vulture activity.
+                      </p>
+                      <p>
+                        Late October is the start of the season — the forest is
+                        still green from the monsoon, the light is soft, and the
+                        park is fresh and uncrowded. It&apos;s a beautiful time
+                        to photograph it.
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* How the days run */}
+                  <div className="border-t border-charcoal/10 pt-12">
+                    <h2 className={SUBHEAD}>How the days run</h2>
+                    <p className={`mt-4 ${BODY_COPY}`}>
+                      Out before first light for the morning safari, with
+                      breakfast carried into the bush so we stay in the field
+                      through the best light. Back to the lodge for lunch and a
+                      quiet middle of the day. Out again for the evening safari
+                      as the light turns. After dinner, a photography and
+                      post-processing session — looking at what came home,
+                      talking through what worked, and building the edit. Six
+                      safaris across the trip.
+                    </p>
+                  </div>
+
+                  {/* Itinerary */}
+                  <div className="border-t border-charcoal/10 pt-12">
+                    <h2 className={SUBHEAD}>The itinerary</h2>
+                    <div className="mt-6 space-y-7">
+                      {ITINERARY.map((block) => (
+                        <div key={block.date}>
+                          <div className="flex flex-wrap items-baseline gap-x-3">
+                            <span className="font-display text-sm tracking-[0.15em] text-sage">
+                              {block.date}
+                            </span>
+                            <h3 className="font-display text-lg font-semibold tracking-tight text-charcoal">
+                              {block.title}
+                            </h3>
+                          </div>
+                          <ul className="mt-3 space-y-1.5">
+                            {block.items.map((item) => (
+                              <li
+                                key={`${item.time}-${item.text}`}
+                                className="grid grid-cols-[4.5rem_1fr] gap-3 text-sm leading-[1.6] text-smoke"
+                              >
+                                <span className="text-sage/90">
+                                  {item.time}
+                                </span>
+                                <span>{item.text}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Inclusions */}
+                  <div className="border-t border-charcoal/10 pt-12">
+                    <h2 className={SUBHEAD}>Inclusions</h2>
+                    <div className="mt-6 grid gap-x-10 gap-y-8 sm:grid-cols-2">
+                      <div>
+                        <p className={MINI_LABEL}>Included</p>
+                        <ul className="mt-4 space-y-2 text-sm leading-[1.6] text-smoke">
+                          {INCLUDED.map((item) => (
+                            <li key={item} className="flex gap-2.5">
+                              <span aria-hidden className="text-sage">
+                                —
+                              </span>
+                              <span>{item}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div>
+                        <p className={MINI_LABEL}>Not included</p>
+                        <ul className="mt-4 space-y-2 text-sm leading-[1.6] text-smoke">
+                          {NOT_INCLUDED.map((item) => (
+                            <li key={item} className="flex gap-2.5">
+                              <span aria-hidden className="text-smoke/40">
+                                —
+                              </span>
+                              <span>{item}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Good to know */}
+                  <div className="border-t border-charcoal/10 pt-12">
+                    <h2 className={SUBHEAD}>Good to know</h2>
+                    <ul className="mt-5 space-y-2.5 text-sm leading-[1.6] text-smoke">
+                      {GOOD_TO_KNOW.map((item) => (
+                        <li key={item} className="flex gap-2.5">
+                          <span aria-hidden className="text-sage">
+                            —
+                          </span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {/* Getting there */}
+                  <div className="border-t border-charcoal/10 pt-12">
+                    <h2 className={SUBHEAD}>Getting there</h2>
+                    <p className={`mt-4 ${BODY_COPY}`}>
+                      The nearest airport is Khajuraho (HJR). Flights are not
+                      included. Suggested routing from Pune:
+                    </p>
+                    <ul className="mt-4 space-y-2.5 text-sm leading-[1.6] text-smoke">
+                      <li className="flex gap-3">
+                        <span
+                          aria-hidden
+                          className="font-display text-[11px] uppercase tracking-[0.2em] text-sage"
+                        >
+                          Out
+                        </span>
+                        <span>
+                          Pune (PNQ) → Khajuraho (HJR), 21 Oct, 05:05 am → 12:15
+                          pm, via Delhi
+                        </span>
+                      </li>
+                      <li className="flex gap-3">
+                        <span
+                          aria-hidden
+                          className="font-display text-[11px] uppercase tracking-[0.2em] text-sage"
+                        >
+                          Return
+                        </span>
+                        <span>
+                          Khajuraho (HJR) → Pune (PNQ), 25 Oct, 2:35 pm → 8:40
+                          pm, via Delhi
+                        </span>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </FadeIn>
+            </div>
+
+            {/* ESSENTIALS CARD — sticky, keeps the enquiry CTA in view */}
+            <aside className="order-1 md:order-2">
+              <div className="border border-charcoal/10 bg-white p-6 md:sticky md:top-28 md:p-7">
+                <p className={MINI_LABEL}>The essentials</p>
+                <dl className="mt-5 divide-y divide-charcoal/10">
+                  {FACTS.map((f) => (
+                    <div
+                      key={f.label}
+                      className="flex items-baseline justify-between gap-4 py-2.5"
+                    >
+                      <dt className="text-xs uppercase tracking-[0.12em] text-smoke/70">
+                        {f.label}
+                      </dt>
+                      <dd className="text-right text-sm font-medium text-charcoal">
+                        {f.value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+                <div className="mt-5 border-t border-charcoal/10 pt-5">
+                  <p className="font-display text-2xl font-semibold tracking-tight text-charcoal">
+                    ₹84,999{" "}
+                    <span className="text-base font-normal text-smoke">
+                      / person
+                    </span>
+                  </p>
+                  <p className="mt-1 text-xs leading-relaxed text-smoke">
+                    Twin sharing. Single room at extra cost (on request).
+                  </p>
+                </div>
+                <ClaimButton className="mt-6 w-full" />
+                <p className="mt-3 text-center text-[11px] uppercase tracking-[0.15em] text-smoke/70">
+                  Limited seats · first come, first served
+                </p>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      {/* ENQUIRE */}
+      <section
+        id="enquire"
+        className="scroll-mt-24 border-t border-charcoal/10 bg-paper py-20 md:py-28"
+      >
+        <div className="mx-auto max-w-2xl px-6 md:px-12">
+          <FadeIn>
+            <div className="text-center">
+              <p className="text-[11px] font-medium uppercase tracking-[0.3em] text-sage">
+                Claim your spot
+              </p>
+              <h2 className="mt-5 font-display text-3xl font-semibold tracking-tight text-charcoal md:text-4xl lg:text-5xl">
+                Enquire about this workshop.
+              </h2>
+              <p className="mt-6 text-base leading-[1.8] text-smoke md:text-lg">
+                Seats are limited and offered on a first-come, first-served
+                basis — reach out early to secure yours. I read every message
+                and reply within 48 hours.
+              </p>
+            </div>
+
+            <div className="mt-12 md:mt-14">
+              <ContactForm
+                source="workshops"
+                theme="light"
+                subject={ENQUIRY_SUBJECT}
+                defaultMessage={ENQUIRY_MESSAGE}
+              />
+            </div>
+          </FadeIn>
+
+          <FadeIn delay={200}>
+            <div className="mt-14 flex items-center justify-center gap-4 md:mt-16">
+              <span className="h-px w-12 bg-charcoal/10" />
+              <span className="text-[11px] uppercase tracking-[0.2em] text-smoke">
+                Or reach out directly
+              </span>
+              <span className="h-px w-12 bg-charcoal/10" />
+            </div>
+
+            <ul className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 md:mt-10 md:gap-x-8">
+              <li>
+                <a
+                  href={WHATSAPP_HREF}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Chat on WhatsApp at ${PHONE_NUMBER_DISPLAY} about the Panna workshop`}
+                  className="group inline-flex items-center gap-2 text-xs text-smoke transition-colors duration-300 hover:text-sage md:text-sm"
+                >
+                  <MessageCircle size={14} strokeWidth={1.5} />
+                  <span className="font-display uppercase tracking-[0.15em]">
+                    WhatsApp
+                  </span>
+                  <span className="tracking-wide">{PHONE_NUMBER_DISPLAY}</span>
+                </a>
+              </li>
+              <li>
+                <a
+                  href={PHONE_TEL}
+                  aria-label={`Call ${PHONE_NUMBER_DISPLAY}`}
+                  className="group inline-flex items-center gap-2 text-xs text-smoke transition-colors duration-300 hover:text-sage md:text-sm"
+                >
+                  <Phone size={14} strokeWidth={1.5} />
+                  <span className="font-display uppercase tracking-[0.15em]">
+                    Call
+                  </span>
+                  <span className="tracking-wide">{PHONE_NUMBER_DISPLAY}</span>
+                </a>
+              </li>
+              <li>
+                <a
+                  href={EMAIL_MAILTO}
+                  aria-label={`Email ${EMAIL}`}
+                  className="group inline-flex items-center gap-2 text-xs text-smoke transition-colors duration-300 hover:text-sage md:text-sm"
+                >
+                  <Mail size={14} strokeWidth={1.5} />
+                  <span className="font-display uppercase tracking-[0.15em]">
+                    Email
+                  </span>
+                  <span className="tracking-wide">{EMAIL}</span>
+                </a>
+              </li>
+              <li>
+                <a
+                  href={INSTAGRAM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Follow on Instagram"
+                  className="group inline-flex items-center gap-2 text-xs text-smoke transition-colors duration-300 hover:text-sage md:text-sm"
+                >
+                  <Instagram size={14} strokeWidth={1.5} />
+                  <span className="font-display uppercase tracking-[0.15em]">
+                    Instagram
+                  </span>
+                  <span className="tracking-wide">@tarang.hirani</span>
+                </a>
+              </li>
+            </ul>
+          </FadeIn>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.taranghirani.com</loc><lastmod>2026-06-09T18:26:24.389Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.taranghirani.com/blog</loc><lastmod>2026-06-09T18:26:24.389Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.taranghirani.com/contact</loc><lastmod>2026-06-09T18:26:24.389Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.taranghirani.com/gallery</loc><lastmod>2026-06-09T18:26:24.389Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.taranghirani.com/workshops</loc><lastmod>2026-06-09T18:26:24.389Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.taranghirani.com/blog/understanding-behavior</loc><lastmod>2026-06-09T18:26:24.389Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.taranghirani.com/blog/shooting-with-intent</loc><lastmod>2026-06-09T18:26:24.389Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com</loc><lastmod>2026-06-19T08:12:00.961Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com/blog</loc><lastmod>2026-06-19T08:12:00.962Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com/contact</loc><lastmod>2026-06-19T08:12:00.962Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com/gallery</loc><lastmod>2026-06-19T08:12:00.962Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com/workshops</loc><lastmod>2026-06-19T08:12:00.962Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com/workshops/panna-october-2026</loc><lastmod>2026-06-19T08:12:00.962Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com/blog/understanding-behavior</loc><lastmod>2026-06-19T08:12:00.962Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.taranghirani.com/blog/shooting-with-intent</loc><lastmod>2026-06-19T08:12:00.962Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
## Summary
Adds a public, indexable landing page for the fixed-date **Panna wildlife photography workshop** (Oct 21–25, 2026) at `/workshops/panna-october-2026`, plus the discovery paths and prefilled enquiry flow around it. Built to look native to the site (existing Layout, type, tokens, `FadeIn`, Cloudinary `next/image`, `next/head` SEO + JSON-LD).

## What's included

**New page — `pages/workshops/panna-october-2026.tsx`**
- Brochure-style, two-column layout: a scannable content column + a **sticky "essentials" card** (dates, length, safaris, price, key facts) that keeps the **"Claim your spot"** CTA in view down the page. Single cover image.
- SEO: correct title/description, OG/Twitter tags with a tiger `og:image`, and valid `Event` JSON-LD (offline, Panna Tiger Reserve / MP, organizer, offer). Uses the global self-referential canonical (no `/index`).

**Enquiry (reuses existing Resend backend)**
- `components/ContactForm.tsx` — optional `subject` (hidden field; hides the type dropdown) and `defaultMessage` (prefilled, editable). Backward-compatible — `/contact` and `/workshops` unchanged.
- `pages/api/contact.ts` — accepts optional `subject`, uses it as the email subject and adds an identifying row to the notification, so Panna leads are obvious.
- Secondary WhatsApp (prefilled message) / call / email / Instagram beside the form.

**Discovery**
- `lib/workshops.ts` — single source of truth (incl. `region`) + `workshopsByRegion()` helper.
- `components/UpcomingWorkshops.tsx` — themeable listing (with a concise, price-free variant) on the **home page** and **`/workshops`**.
- `components/Navbar.tsx` — **Workshops dropdown grouped by region**, linking to dated pages (desktop hover/focus panel + mobile indented submenu). Grows automatically as workshops are added to the data file.
- Regenerated `public/sitemap-0.xml` to include the new page.

## Verification
- Clean `yarn build` passes (Node 22 per repo engine); page prerenders static.
- One H1; title/description/canonical correct; `og:image` returns 200; `Event` JSON-LD complete.
- Two `#enquire` CTAs (hero + sticky card); form prefilled (subject + message), submission tagged `source: workshops`.
- Linked from home, nav dropdown, and `/workshops`; present in sitemap.
- Images carry descriptive alt; captions don't claim Panna.

## Notes
- Desktop dropdown is hover + keyboard-focus accessible; no Escape-to-close handler yet (CSS-driven panel).
- `og:image` uses a strong tiger frame; the on-page hero uses the requested forest-pool frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)