### PR TITLE
Record contact-form enquiries in Notion (alongside email)

### DIFF
--- a/docs/notion-integration.md
+++ b/docs/notion-integration.md
@@ -1,0 +1,75 @@
+# Notion Enquiry CRM
+
+## Context
+
+Every contact-form submission is emailed via Resend (see
+[contact-form-rollout.md](./contact-form-rollout.md)). Email alone is a push
+notification, not a record you can work — so each enquiry is **also** appended to
+a Notion database that doubles as a lightweight CRM (a status pipeline you drag
+leads through: New → Contacted → Quoted → Booked / Lost).
+
+The Notion write is **best-effort and additive**: it runs in
+`pages/api/contact.ts` only after the notification email has already succeeded,
+inside a `try/catch`. If Notion is unconfigured or errors, it's logged and the
+request still returns `{ success: true }` — the email flow, honeypot, and
+acknowledgement are never affected.
+
+```
+Form submission → Resend → inbox (notification + acknowledgement)
+                     ↓
+              Notion database (CRM row, Status = New)
+```
+
+## How it works in code
+
+- `lib/notion.ts` — `recordEnquiryInNotion(enquiry)` builds the page properties
+  and calls `notion.pages.create`. No-ops with a warning if the env vars are
+  missing (so local dev without Notion works). Long text (`Message`, `Subject`)
+  is split into ≤2000-char chunks because Notion caps a single rich_text chunk at
+  2000 characters.
+- `pages/api/contact.ts` — calls the helper best-effort after the notification
+  email send.
+
+## One-time Notion setup
+
+1. **Create an internal integration** at <https://www.notion.so/my-integrations>
+   ("New integration", capability: Insert content). Copy the Internal Integration
+   Secret.
+2. **Create a full-page database** with the properties in the schema below. Names
+   and types must match exactly — the code writes to these property names.
+3. **Share the database with the integration**: open the database → `•••` →
+   Connections → connect your integration. *(Skipping this gives a 404 even with
+   a valid ID.)*
+4. **Copy the database ID** — the 32-char hex string in the database URL, before
+   `?v=`: `notion.so/<workspace>/<DATABASE_ID>?v=...`.
+
+## Database schema
+
+| Property      | Type   | Source                                   |
+| ------------- | ------ | ---------------------------------------- |
+| **Name**      | Title  | `name`                                   |
+| **Email**     | Email  | `email`                                  |
+| **Phone**     | Phone  | `countryCode` + `phone`                  |
+| **Type**      | Select | `type` (`Workshop`, `Safari`, `Other`)   |
+| **Subject**   | Text   | `subject` (fixed enquiry, e.g. workshop) |
+| **Source**    | Select | `source` (`contact`, `workshops`)        |
+| **Message**   | Text   | `message`                                |
+| **Status**    | Select | always set to `New` on insert            |
+| **Submitted** | Date   | server timestamp                         |
+
+`Status` options to pre-create: `New`, `Contacted`, `Quoted`, `Booked`, `Lost`.
+
+## Environment variables
+
+Set in `.env.local` (local) and Vercel → Settings → Environment Variables
+(Production + Preview):
+
+```
+NOTION_ACCESS_TOKEN=<integration secret>
+NOTION_DATABASE_ID=<32-char database id>
+```
+
+## Note on the package
+
+`@notionhq/client` is pinned to `2.3.0`. The 3.x line requires Node 22; this
+project currently runs on Node 20, so the 2.x line is used.

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,0 +1,69 @@
+import { Client } from "@notionhq/client";
+
+// A contact-form enquiry, already trimmed and validated by the API route.
+export type Enquiry = {
+  name: string;
+  email: string;
+  fullPhone: string;
+  type: string;
+  subject: string;
+  source: string;
+  message: string;
+};
+
+// Notion caps a single rich_text content chunk at 2000 characters. The message
+// field is validated to <= 5000, so split it across multiple chunks.
+const NOTION_TEXT_CHUNK = 2000;
+
+function richText(value: string) {
+  const chunks: { text: { content: string } }[] = [];
+  for (let i = 0; i < value.length; i += NOTION_TEXT_CHUNK) {
+    chunks.push({ text: { content: value.slice(i, i + NOTION_TEXT_CHUNK) } });
+  }
+  return chunks;
+}
+
+/**
+ * Append an enquiry to the Notion database as a new page (CRM row).
+ *
+ * Best-effort by design: if the env vars are missing it no-ops with a warning so
+ * local dev without Notion still works, and any API failure throws to the caller
+ * which logs it without failing the request (the notification email already
+ * succeeded by the time this runs).
+ */
+export async function recordEnquiryInNotion(enquiry: Enquiry): Promise<void> {
+  const auth = process.env.NOTION_ACCESS_TOKEN;
+  const databaseId = process.env.NOTION_DATABASE_ID;
+
+  if (!auth || !databaseId) {
+    console.warn(
+      "Notion not configured (NOTION_ACCESS_TOKEN / NOTION_DATABASE_ID missing) — skipping enquiry record",
+    );
+    return;
+  }
+
+  const notion = new Client({ auth });
+
+  const properties: Record<string, unknown> = {
+    Name: { title: [{ text: { content: enquiry.name } }] },
+    Email: { email: enquiry.email },
+    Phone: { phone_number: enquiry.fullPhone },
+    Message: { rich_text: richText(enquiry.message) },
+    Status: { select: { name: "New" } },
+    // The database's "Created Date" (created_time) auto-captures submission time,
+    // so there is no timestamp property to write here.
+  };
+
+  // Optional fields: omit empty selects/text — the Notion API rejects an empty
+  // select option name.
+  if (enquiry.type) properties.Type = { select: { name: enquiry.type } };
+  if (enquiry.source) properties.Source = { select: { name: enquiry.source } };
+  if (enquiry.subject)
+    properties.Subject = { rich_text: richText(enquiry.subject) };
+
+  await notion.pages.create({
+    parent: { database_id: databaseId },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    properties: properties as any,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "node": "22.x"
   },
   "dependencies": {
+    "@notionhq/client": "2.3.0",
     "@svgr/webpack": "8.1.0",
     "cloudinary": "2.6.1",
     "lucide-react": "0.556.0",

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Resend } from "resend";
+import { recordEnquiryInNotion } from "../../lib/notion";
 
 const TO_ADDRESSES = ["safaris@taranghirani.com", "tarang9211@gmail.com"];
 const FROM_ADDRESS =
@@ -177,6 +178,22 @@ export default async function handler(
     if (error) {
       console.error("Resend send error:", error);
       return res.status(500).json({ error: "Failed to send message" });
+    }
+
+    // Best-effort CRM record in Notion. A failure here is logged but must not
+    // fail the request — the notification email above already succeeded.
+    try {
+      await recordEnquiryInNotion({
+        name: trimmed.name,
+        email: trimmed.email,
+        fullPhone,
+        type,
+        subject: subjectField,
+        source,
+        message: trimmed.message,
+      });
+    } catch (notionErr) {
+      console.error("Notion record failed:", notionErr);
     }
 
     // Best-effort acknowledgement to the enquirer. A failure here is logged but

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,6 +1369,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@notionhq/client@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@notionhq/client/-/client-2.3.0.tgz#4feecb012ebcd4116df14a9e2c77afed7eeb73cd"
+  integrity sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==
+  dependencies:
+    "@types/node-fetch" "^2.5.10"
+    node-fetch "^2.6.1"
+
 "@npmcli/arborist@^5.6.3":
   version "5.6.3"
   resolved "https://registry.npmjs.org/@npmcli/arborist/-/arborist-5.6.3.tgz"
@@ -1727,6 +1735,21 @@
   resolved "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/node-fetch@^2.5.10":
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.13.tgz#e0c9b7b5edbdb1b50ce32c127e85e880872d56ee"
+  integrity sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.4"
+
+"@types/node@*":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.0.0.tgz#d4aece9e9412e9f2008d59bc2d74f5279316b665"
+  integrity sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==
+  dependencies:
+    undici-types "~8.3.0"
+
 "@types/node@22.15.18":
   version "22.15.18"
   resolved "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz"
@@ -1852,6 +1875,11 @@ asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 autoprefixer@10.4.19:
   version "10.4.19"
@@ -1990,6 +2018,14 @@ cacache@^16.0.0, cacache@^16.1.0, cacache@^16.1.3:
     ssri "^9.0.0"
     tar "^6.1.11"
     unique-filename "^2.0.0"
+
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -2143,6 +2179,13 @@ columnify@^1.6.0:
   dependencies:
     strip-ansi "^6.0.1"
     wcwidth "^1.0.0"
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 commander@^4.0.0:
   version "4.1.1"
@@ -2348,6 +2391,11 @@ del@^6.0.0:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
@@ -2426,6 +2474,15 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
@@ -2479,6 +2536,33 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 esbuild@~0.27.0:
   version "0.27.4"
@@ -2600,6 +2684,17 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
+form-data@^4.0.4:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+
 fraction.js@^4.3.7:
   version "4.3.7"
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz"
@@ -2654,6 +2749,30 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stream@^6.0.0:
   version "6.0.1"
@@ -2733,6 +2852,11 @@ globby@^11.0.1:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graceful-fs@4.2.10:
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
@@ -2753,6 +2877,18 @@ has-flag@^4.0.0:
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-symbols@^1.0.3, has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
+
 has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
@@ -2762,6 +2898,13 @@ hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -3261,6 +3404,11 @@ make-fetch-happen@^10.0.3, make-fetch-happen@^10.0.6, make-fetch-happen@^10.2.0:
     socks-proxy-agent "^7.0.0"
     ssri "^9.0.0"
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
 mdn-data@2.0.28:
   version "2.0.28"
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz"
@@ -3288,6 +3436,18 @@ micromatch@^4.0.5, micromatch@^4.0.8:
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -3494,6 +3654,13 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-fetch@^2.6.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp@^9.0.0, node-gyp@^9.1.0:
   version "9.4.1"
@@ -4671,6 +4838,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 treeverse@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/treeverse/-/treeverse-2.0.0.tgz"
@@ -4715,6 +4887,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"
@@ -4812,6 +4989,19 @@ wcwidth@^1.0.0:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1, which@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
## What & why

Contact-form enquiries were email-only — a push notification, not a record you can work. Each submission is now **also** appended to a Notion database that doubles as a lightweight CRM (Status pipeline: `New → Contacted → Quoted → Booked / Lost`), so leads become something you manage and convert.

The Notion write is **additive and best-effort** — it changes nothing about the existing behaviour:
- Runs in `pages/api/contact.ts` **only after the notification email succeeds**, inside a `try/catch`.
- A missing or failing Notion config is logged but **never fails the request** (`{ success: true }` still returned).
- Email notification, enquirer acknowledgement, honeypot, validation, and the Meta Pixel `Lead` event are untouched.

## Changes

- **`lib/notion.ts`** (new) — `recordEnquiryInNotion()` maps form fields → Notion page properties. No-ops with a warning when env vars are absent (local dev without Notion still works); chunks long text into ≤2000-char `rich_text` segments (Notion's per-chunk cap). Submission time comes from the database's auto `Created Date` property — no timestamp is written.
- **`pages/api/contact.ts`** — best-effort call to the helper after the notification email send.
- **`package.json` / `yarn.lock`** — add `@notionhq/client@2.3.0` (3.x requires Node 22; project is on Node 20).
- **`docs/notion-integration.md`** (new) — integration/database/sharing setup, property schema, and env vars.

## Database property mapping

| Notion property | Type | Source |
|---|---|---|
| Name | Title | `name` |
| Email | Email | `email` |
| Phone | Phone | `countryCode` + `phone` |
| Type | Select | `type` (optional) |
| Subject | Text | `subject` (optional) |
| Source | Select | `source` (optional) |
| Message | Text | `message` |
| Status | Select | always `New` on insert |
| Created Date | created_time | auto (Notion) |

## Env vars (already set locally; **must be added to Vercel** Production + Preview)

```
NOTION_ACCESS_TOKEN=<integration secret>
NOTION_DATABASE_ID=<32-char database id>
```

The Notion integration must also be connected to the database (`••• → Connections`).

## Verification

Ran the full path against the live database via a throwaway script (since removed): a row was created with every field populated, `Status = New`, `Created Date` auto-set, and a 2159-char message stored intact (chunking verified). Failure isolation is covered by the `try/catch` wrapper. `tsc --noEmit` passes. The test row was archived afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)