### PR TITLE
Update Panna Oct 2026 workshop price to ₹94,999

### DIFF
--- a/lib/workshops.ts
+++ b/lib/workshops.ts
@@ -30,7 +30,7 @@ export const UPCOMING_WORKSHOPS: Workshop[] = [
     location: "Panna, Madhya Pradesh",
     dateLabel: "Oct 21–25, 2026",
     summary:
-      "4 nights / 5 days · 6 safaris · ₹104,999 per person (twin sharing). Limited seats, first come, first served.",
+      "4 nights / 5 days · 6 safaris · ₹94,999 per person (twin sharing). Limited seats, first come, first served.",
     shortSummary: "Limited seats, first come, first served.",
     image: `${CLOUDINARY_BASE}/_Z9_20250508_TMH_8461_wm_vwr6rk`,
     imageAlt:

--- a/lib/workshops.ts
+++ b/lib/workshops.ts
@@ -30,7 +30,7 @@ export const UPCOMING_WORKSHOPS: Workshop[] = [
     location: "Panna, Madhya Pradesh",
     dateLabel: "Oct 21–25, 2026",
     summary:
-      "4 nights / 5 days · 6 safaris · ₹84,999 per person (twin sharing). Limited seats, first come, first served.",
+      "4 nights / 5 days · 6 safaris · ₹104,999 per person (twin sharing). Limited seats, first come, first served.",
     shortSummary: "Limited seats, first come, first served.",
     image: `${CLOUDINARY_BASE}/_Z9_20250508_TMH_8461_wm_vwr6rk`,
     imageAlt:

--- a/pages/workshops/panna-october-2026.tsx
+++ b/pages/workshops/panna-october-2026.tsx
@@ -62,7 +62,7 @@ const JSON_LD = {
   },
   offers: {
     "@type": "Offer",
-    price: "104999",
+    price: "94999",
     priceCurrency: "INR",
     availability: "https://schema.org/LimitedAvailability",
     url: PAGE_URL,
@@ -224,7 +224,7 @@ export default function PannaWorkshopPage() {
                 </h1>
                 <p className="mt-5 max-w-2xl text-base leading-[1.7] text-white/85 md:text-lg">
                   Oct 21–25, 2026 · 4 nights / 5 days · 6 safaris · Limited
-                  seats · ₹104,999 per person (twin sharing)
+                  seats · ₹94,999 per person (twin sharing)
                 </p>
                 <ClaimButton className="mt-8" />
               </div>
@@ -440,7 +440,7 @@ export default function PannaWorkshopPage() {
                 </dl>
                 <div className="mt-5 border-t border-charcoal/10 pt-5">
                   <p className="font-display text-2xl font-semibold tracking-tight text-charcoal">
-                    ₹104,999{" "}
+                    ₹94,999{" "}
                     <span className="text-base font-normal text-smoke">
                       / person
                     </span>

--- a/pages/workshops/panna-october-2026.tsx
+++ b/pages/workshops/panna-october-2026.tsx
@@ -62,7 +62,7 @@ const JSON_LD = {
   },
   offers: {
     "@type": "Offer",
-    price: "84999",
+    price: "104999",
     priceCurrency: "INR",
     availability: "https://schema.org/LimitedAvailability",
     url: PAGE_URL,
@@ -224,7 +224,7 @@ export default function PannaWorkshopPage() {
                 </h1>
                 <p className="mt-5 max-w-2xl text-base leading-[1.7] text-white/85 md:text-lg">
                   Oct 21–25, 2026 · 4 nights / 5 days · 6 safaris · Limited
-                  seats · ₹84,999 per person (twin sharing)
+                  seats · ₹104,999 per person (twin sharing)
                 </p>
                 <ClaimButton className="mt-8" />
               </div>
@@ -440,7 +440,7 @@ export default function PannaWorkshopPage() {
                 </dl>
                 <div className="mt-5 border-t border-charcoal/10 pt-5">
                   <p className="font-display text-2xl font-semibold tracking-tight text-charcoal">
-                    ₹84,999{" "}
+                    ₹104,999{" "}
                     <span className="text-base font-normal text-smoke">
                       / person
                     </span>


### PR DESCRIPTION
## Summary
Sets the Panna (October 2026) workshop price to **₹94,999** per person (was ₹84,999).

Updated everywhere the figure appears so the visible price and SEO/structured data stay in sync:
- `pages/workshops/panna-october-2026.tsx` — JSON-LD `price`, hero seats line, and price card
- `lib/workshops.ts` — listing summary (drives the workshops index + prefilled enquiry)

## Verification
- `grep -rn "84,999\|84999\|104,999\|104999"` (excluding node_modules) returns no matches for the page/listing source.
- Load `/workshops/panna-october-2026` and confirm the price card, seats line, and listing all read ₹94,999.
- Page source JSON-LD shows `"price":"94999"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)