### PR TITLE
Change Panna Oct 2026 workshop price to "On enquiry"

### DIFF
--- a/lib/workshops.ts
+++ b/lib/workshops.ts
@@ -30,7 +30,7 @@ export const UPCOMING_WORKSHOPS: Workshop[] = [
     location: "Panna, Madhya Pradesh",
     dateLabel: "Oct 21–25, 2026",
     summary:
-      "4 nights / 5 days · 6 safaris · Price on enquiry. Limited seats, first come, first served.",
+      "4 nights / 5 days · 6 safaris · Price on enquiry (twin sharing). Limited seats, first come, first served.",
     shortSummary: "Limited seats, first come, first served.",
     image: `${CLOUDINARY_BASE}/_Z9_20250508_TMH_8461_wm_vwr6rk`,
     imageAlt:

--- a/lib/workshops.ts
+++ b/lib/workshops.ts
@@ -30,7 +30,7 @@ export const UPCOMING_WORKSHOPS: Workshop[] = [
     location: "Panna, Madhya Pradesh",
     dateLabel: "Oct 21–25, 2026",
     summary:
-      "4 nights / 5 days · 6 safaris · ₹94,999 per person (twin sharing). Limited seats, first come, first served.",
+      "4 nights / 5 days · 6 safaris · Price on enquiry. Limited seats, first come, first served.",
     shortSummary: "Limited seats, first come, first served.",
     image: `${CLOUDINARY_BASE}/_Z9_20250508_TMH_8461_wm_vwr6rk`,
     imageAlt:

--- a/pages/workshops/panna-october-2026.tsx
+++ b/pages/workshops/panna-october-2026.tsx
@@ -62,8 +62,6 @@ const JSON_LD = {
   },
   offers: {
     "@type": "Offer",
-    price: "94999",
-    priceCurrency: "INR",
     availability: "https://schema.org/LimitedAvailability",
     url: PAGE_URL,
   },
@@ -224,7 +222,7 @@ export default function PannaWorkshopPage() {
                 </h1>
                 <p className="mt-5 max-w-2xl text-base leading-[1.7] text-white/85 md:text-lg">
                   Oct 21–25, 2026 · 4 nights / 5 days · 6 safaris · Limited
-                  seats · ₹94,999 per person (twin sharing)
+                  seats · Price on enquiry
                 </p>
                 <ClaimButton className="mt-8" />
               </div>
@@ -440,10 +438,7 @@ export default function PannaWorkshopPage() {
                 </dl>
                 <div className="mt-5 border-t border-charcoal/10 pt-5">
                   <p className="font-display text-2xl font-semibold tracking-tight text-charcoal">
-                    ₹94,999{" "}
-                    <span className="text-base font-normal text-smoke">
-                      / person
-                    </span>
+                    On enquiry
                   </p>
                   <p className="mt-1 text-xs leading-relaxed text-smoke">
                     Twin sharing. Single room at extra cost (on request).

--- a/pages/workshops/panna-october-2026.tsx
+++ b/pages/workshops/panna-october-2026.tsx
@@ -222,7 +222,7 @@ export default function PannaWorkshopPage() {
                 </h1>
                 <p className="mt-5 max-w-2xl text-base leading-[1.7] text-white/85 md:text-lg">
                   Oct 21–25, 2026 · 4 nights / 5 days · 6 safaris · Limited
-                  seats · Price on enquiry
+                  seats · Price on enquiry (twin sharing)
                 </p>
                 <ClaimButton className="mt-8" />
               </div>


### PR DESCRIPTION
## Summary
Stops publishing the fixed ₹94,999 price for the Panna Oct 2026 workshop and presents it as **"On enquiry"** instead, so pricing is quoted per-enquiry.

## Changes
- **`lib/workshops.ts`** — listing card summary: `Price on enquiry` replaces `₹94,999 per person (twin sharing)`
- **Hero subtitle** — `Limited seats · Price on enquiry`
- **Essentials card** — prominent price now reads `On enquiry` (twin-sharing caption retained)
- **JSON-LD `Offer`** — dropped `price`/`priceCurrency` (no public price quoted); `availability` + `url` retained

## Verification
- `grep` confirms no `₹`/`94999` references remain in either file
- Poster scripts left untouched (out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)