### PR TITLE
Auto-subscribe enquiry-form leads to the Kit newsletter

### DIFF
--- a/docs/email-capture-kit-integration.md
+++ b/docs/email-capture-kit-integration.md
@@ -91,6 +91,12 @@ Kit needs DNS records on taranghirani.com so emails from safaris@taranghirani.co
 
 **New file:** `/pages/api/subscribe.ts`
 
+> **Update (July 2026):** The Kit API logic now lives in a shared helper,
+> `/lib/kit.ts` (`subscribeToNewsletter`). Besides `/api/subscribe`, the
+> contact form route (`/pages/api/contact.ts`) calls it best-effort so every
+> enquiry lead is auto-subscribed to the newsletter (with their first name).
+> A Kit failure never fails the enquiry.
+
 ### Flow
 
 ```

--- a/lib/kit.ts
+++ b/lib/kit.ts
@@ -1,0 +1,94 @@
+export type KitSubscribeResult = {
+  ok: boolean;
+  alreadySubscribed?: boolean;
+  reason?: "not_configured" | "invalid_input" | "error";
+};
+
+/**
+ * Subscribe an email address to the newsletter via the Kit (ConvertKit) v4
+ * API: create-or-find the subscriber, then attach it to the signup form
+ * (idempotent; triggers the form's automations).
+ *
+ * Never throws — callers that treat subscription as best-effort (e.g. the
+ * contact route) can ignore the result, while /api/subscribe maps the
+ * failure reason onto its response contract.
+ */
+export async function subscribeToNewsletter({
+  email,
+  firstName,
+}: {
+  email: string;
+  firstName?: string;
+}): Promise<KitSubscribeResult> {
+  const apiSecret = process.env.KIT_API_SECRET;
+  const formId = process.env.KIT_FORM_ID;
+
+  if (!apiSecret || !formId) {
+    console.warn(
+      "Missing KIT_API_SECRET or KIT_FORM_ID environment variables — skipping newsletter subscription",
+    );
+    return { ok: false, reason: "not_configured" };
+  }
+
+  const kitHeaders = {
+    "X-Kit-Api-Key": apiSecret,
+    "Content-Type": "application/json",
+  };
+
+  try {
+    // Step 1: create-or-find subscriber. Kit returns 201 for new, 200 for existing.
+    const createRes = await fetch("https://api.kit.com/v4/subscribers", {
+      method: "POST",
+      headers: kitHeaders,
+      body: JSON.stringify({
+        email_address: email,
+        ...(firstName ? { first_name: firstName } : {}),
+      }),
+    });
+
+    if (!createRes.ok) {
+      console.error(
+        "Kit create subscriber error:",
+        createRes.status,
+        await createRes.text(),
+      );
+      // 4xx from Kit means our input was bad (e.g., invalid email format).
+      const reason =
+        createRes.status >= 400 && createRes.status < 500
+          ? "invalid_input"
+          : "error";
+      return { ok: false, reason };
+    }
+
+    const createJson = (await createRes.json()) as {
+      subscriber?: { id?: number };
+    };
+    const subscriberId = createJson.subscriber?.id;
+    const alreadySubscribed = createRes.status === 200;
+
+    if (!subscriberId) {
+      console.error("Kit create subscriber returned no id:", createJson);
+      return { ok: false, reason: "error" };
+    }
+
+    // Step 2: attach subscriber to the form (idempotent; triggers form automations).
+    const attachRes = await fetch(
+      `https://api.kit.com/v4/forms/${formId}/subscribers/${subscriberId}`,
+      { method: "POST", headers: kitHeaders },
+    );
+
+    if (!attachRes.ok) {
+      console.error(
+        "Kit attach-to-form error:",
+        attachRes.status,
+        await attachRes.text(),
+      );
+      return { ok: false, reason: "error" };
+    }
+
+    return { ok: true, alreadySubscribed };
+  } catch (err) {
+    console.error("Kit API request failed:", err);
+    return { ok: false, reason: "error" };
+  }
+}

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Resend } from "resend";
 import { recordEnquiryInNotion } from "../../lib/notion";
+import { subscribeToNewsletter } from "../../lib/kit";
 
 const TO_ADDRESSES = ["safaris@taranghirani.com", "tarang9211@gmail.com"];
 const FROM_ADDRESS =
@@ -195,6 +196,13 @@ export default async function handler(
     } catch (notionErr) {
       console.error("Notion record failed:", notionErr);
     }
+
+    // Best-effort newsletter subscription — a Kit failure must not fail the
+    // enquiry. subscribeToNewsletter never throws; failures are logged inside.
+    await subscribeToNewsletter({
+      email: trimmed.email,
+      firstName: trimmed.name.split(/\s+/)[0],
+    });
 
     // Best-effort acknowledgement to the enquirer. A failure here is logged but
     // must not fail the request — the notification above already succeeded.

--- a/pages/api/subscribe.ts
+++ b/pages/api/subscribe.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { subscribeToNewsletter } from "../../lib/kit";
 
 export default async function handler(
   req: NextApiRequest,
@@ -24,75 +25,22 @@ export default async function handler(
       .json({ error: "Please enter a valid email address" });
   }
 
-  const apiSecret = process.env.KIT_API_SECRET;
-  const formId = process.env.KIT_FORM_ID;
+  const result = await subscribeToNewsletter({ email });
 
-  if (!apiSecret || !formId) {
-    console.error(
-      "Missing KIT_API_SECRET or KIT_FORM_ID environment variables",
-    );
-    return res.status(500).json({ error: "Server configuration error" });
+  if (result.ok) {
+    return res
+      .status(200)
+      .json({ success: true, alreadySubscribed: result.alreadySubscribed });
   }
 
-  const kitHeaders = {
-    "X-Kit-Api-Key": apiSecret,
-    "Content-Type": "application/json",
-  };
-
-  try {
-    // Step 1: create-or-find subscriber. Kit returns 201 for new, 200 for existing.
-    const createRes = await fetch("https://api.kit.com/v4/subscribers", {
-      method: "POST",
-      headers: kitHeaders,
-      body: JSON.stringify({ email_address: email }),
-    });
-
-    if (!createRes.ok) {
-      console.error(
-        "Kit create subscriber error:",
-        createRes.status,
-        await createRes.text(),
-      );
-      // 4xx from Kit means our input was bad (e.g., invalid email format) —
-      // surface as 400 so the client can show a useful message.
-      const status =
-        createRes.status >= 400 && createRes.status < 500 ? 400 : 500;
-      const message =
-        status === 400
-          ? "Please enter a valid email address"
-          : "Failed to subscribe";
-      return res.status(status).json({ error: message });
-    }
-
-    const createJson = (await createRes.json()) as {
-      subscriber?: { id?: number };
-    };
-    const subscriberId = createJson.subscriber?.id;
-    const alreadySubscribed = createRes.status === 200;
-
-    if (!subscriberId) {
-      console.error("Kit create subscriber returned no id:", createJson);
+  switch (result.reason) {
+    case "invalid_input":
+      return res
+        .status(400)
+        .json({ error: "Please enter a valid email address" });
+    case "not_configured":
+      return res.status(500).json({ error: "Server configuration error" });
+    default:
       return res.status(500).json({ error: "Failed to subscribe" });
-    }
-
-    // Step 2: attach subscriber to the form (idempotent; triggers form automations).
-    const attachRes = await fetch(
-      `https://api.kit.com/v4/forms/${formId}/subscribers/${subscriberId}`,
-      { method: "POST", headers: kitHeaders },
-    );
-
-    if (!attachRes.ok) {
-      console.error(
-        "Kit attach-to-form error:",
-        attachRes.status,
-        await attachRes.text(),
-      );
-      return res.status(500).json({ error: "Failed to subscribe" });
-    }
-
-    return res.status(200).json({ success: true, alreadySubscribed });
-  } catch (err) {
-    console.error("Kit API request failed:", err);
-    return res.status(500).json({ error: "Failed to subscribe" });
   }
 }


### PR DESCRIPTION
## Summary
- Every contact-form enquiry now also subscribes the lead to the Kit (ConvertKit) newsletter automatically — no UI change, no new fields.
- Extracted the Kit v4 API logic from `pages/api/subscribe.ts` into a shared `lib/kit.ts` helper (`subscribeToNewsletter`), which now also sends the subscriber's first name to Kit.
- `pages/api/contact.ts` calls the helper best-effort after the notification email succeeds — a Kit failure or missing `KIT_API_SECRET`/`KIT_FORM_ID` is logged and skipped, never failing the enquiry (same pattern as the Notion step).
- `/api/subscribe` keeps its exact response contract (`success`/`alreadySubscribed`, 400 on invalid email, 500 otherwise), so `EmailSignup` is unchanged.

## Testing
- `tsc --noEmit` clean.
- Live dev server: `/api/subscribe` returns `alreadySubscribed: false` then `true` on repeat, 400 on malformed email (regression check on the refactor).
- `/api/contact` with a full payload returned 200; a direct Kit API query confirmed the lead active in Kit with `first_name` populated.
- Negative path: with `KIT_API_SECRET` blanked, the enquiry still returned 200 (email + Notion unaffected) and logged the skip warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)