### PR TITLE
Update Meta Pixel ID to 1764170624923526

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,7 @@ import Layout from "../components/Layout";
 import "../styles/globals.css";
 
 const GA_MEASUREMENT_ID = "G-JBM6SPGXWS";
-const META_PIXEL_ID = "1340182068044541";
+const META_PIXEL_ID = "1764170624923526";
 
 export default function MyApp({ Component, pageProps }) {
   const router = useRouter();


### PR DESCRIPTION
Updates the Meta Pixel ID in `pages/_app.js` from `1340182068044541` to `1764170624923526`.

The ID is referenced via the `META_PIXEL_ID` constant across the pixel init, `PageView` track call, and the `<noscript>` fallback image, so this single change covers all usages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)